### PR TITLE
Helpers uses the available dependencies.

### DIFF
--- a/lib/aurora_uix_web/template.ex
+++ b/lib/aurora_uix_web/template.ex
@@ -144,8 +144,6 @@ defmodule AuroraUixWeb.Template do
   """
   @callback parse_layout(path :: map, parsed_opts :: map, type :: atom) :: binary
 
-  @callback common_modules() :: list
-
   @callback default_core_components() :: module
 
   @doc """

--- a/lib/aurora_uix_web/templates/core.ex
+++ b/lib/aurora_uix_web/templates/core.ex
@@ -81,19 +81,6 @@ defmodule AuroraUixWeb.Templates.Core do
   defdelegate generate_view(type, parsed_opts), to: MarkupGenerator
 
   @doc """
-  Returns a list of common modules used across the template system.
-
-  ## Returns
-    * [{atom, module}]: List of tuples containing module aliases and their corresponding modules
-  """
-  @spec common_modules :: [{atom, module}]
-  def common_modules do
-    [
-      {:aurora_core_helpers, AuroraUixWeb.Core.Helpers}
-    ]
-  end
-
-  @doc """
   Returns the default core components module used in the template system.
   ## Returns
     * module: The default core components module

--- a/lib/aurora_uix_web/templates/core/helpers.ex
+++ b/lib/aurora_uix_web/templates/core/helpers.ex
@@ -1,144 +1,172 @@
 defmodule AuroraUixWeb.Templates.Core.Helpers do
   @moduledoc """
-  Provides helper functions and macros for managing LiveView components and templates
-  in the AuroraUixWeb application.
+  Helper functions for LiveView components.
   """
+
+  use Phoenix.Component
+  use Phoenix.LiveComponent
+
+  import AuroraUixWeb.Template, only: [safe_existing_atom: 1]
+
+  alias Phoenix.LiveView.JS
 
   @doc """
-  Dynamically generates a module with helper functions for LiveView components.
+  Assigns a new entity to the socket based on related parameters.
 
   ## Parameters
-    - `modules` (map): A map containing module dependencies.
-    - `:aurora_core_helpers` (atom): The atom specifying the helper type.
-    - `_parsed_opts` (map): Additional options for customization.
-
-  ## Returns
-    - `Macro.t()`: A quoted expression defining the generated module.
+    * `socket` - The LiveView socket.
+    * `params` - A map containing optional "related_key" and "parent_id" keys for relationship setup.
+    * `default` - The default entity struct to use when creating a new entity.
   """
-  @spec generate_module(map, atom, map) :: Macro.t()
-  def generate_module(modules, :aurora_core_helpers, _parsed_opts) do
-    aurora_core_helpers = AuroraUixWeb.Core.Helpers
+  def assign_new_entity(
+        socket,
+        %{"related_key" => related_key, "parent_id" => parent_id},
+        default
+      ) do
+    related_key
+    |> safe_existing_atom()
+    |> __maybe_set_related_to_new_entity__(socket, parent_id, default)
+  end
 
-    quote do
-      defmodule unquote(aurora_core_helpers) do
-        @moduledoc false
+  @spec assign_new_entity(Phoenix.Socket.t(), map, map) :: Phoenix.Socket.t()
+  def assign_new_entity(socket, _params, default) do
+    assign(socket, :auix_entity, default)
+  end
 
-        use unquote(modules.web), :live_component
-        import AuroraUixWeb.Template, only: [safe_existing_atom: 1]
+  @doc """
+  Assigns source-related data to the socket based on provided parameters.
 
-        alias Phoenix.LiveView.JS
+  ## Parameters
+    * `socket` - The LiveView socket.
+    * `params` - A map that may contain a "source" key.
+    * `default_source` - The default source value to use when no source is provided.
+  """
+  @spec assign_source(Phoenix.LiveView.Socket.t(), map, binary) ::
+          Phoenix.LiveView.Socket.t()
+  def assign_source(socket, params, default_source) do
+    params
+    |> Map.get("source")
+    |> __maybe_set_different_source_and_link__(socket, default_source)
+  end
 
-        @doc false
-        def assign_new_entity(
-              socket,
-              %{"related_key" => related_key, "parent_id" => parent_id},
-              default
-            ) do
-          related_key
-          |> safe_existing_atom()
-          |> __maybe_set_related_to_new_entity__(socket, parent_id, default)
+  @doc """
+  Assigns click handler for index rows based on parsed options.
+
+  ## Parameters
+    * `socket` - The LiveView socket.
+    * `_params` - Unused parameters map.
+    * `parsed_opts` - Options map containing :disable_index_row_click and :index_row_click settings.
+  """
+  @spec assign_index_row_click(Phoenix.LiveView.Socket.t(), map, map) ::
+          Phoenix.LiveView.Socket.t()
+  def assign_index_row_click(socket, _params, parsed_opts) do
+    index_row_click =
+      if parsed_opts[:disable_index_row_click],
+        do: nil,
+        else: fn {_id, row} ->
+          id = Map.get(row, :id)
+
+          parsed_opts
+          |> Map.get(:index_row_click, "#")
+          |> String.replace("[[entity]]", id)
+          |> then(&navigate/1)
         end
 
-        def assign_new_entity(socket, params, default) do
-          assign(socket, :auix_entity, default)
-        end
+    assign_auix(socket, :index_row_click, index_row_click)
+  end
 
-        @doc false
-        @spec assign_source(Phoenix.LiveView.Socket.t(), map, binary) ::
-                Phoenix.LiveView.Socket.t()
-        def assign_source(socket, params, default_source) do
-          params
-          |> Map.get("source")
-          |> __maybe_set_different_source_and_link__(socket, default_source)
-        end
+  @doc """
+  Assigns a value to the _auix assigns map in the socket.
 
-        @spec assign_index_row_click(Phoenix.LiveView.Socket.t(), map, map) ::
-                Phoenix.LiveView.Socket.t()
-        def assign_index_row_click(socket, _params, parsed_opts) do
-          index_row_click =
-            if parsed_opts[:disable_index_row_click],
-              do: nil,
-              else: fn {_id, row} ->
-                id = Map.get(row, :id)
+  ## Parameters
+    * `socket` - The LiveView socket.
+    * `key` - The key under which to store the value in _auix.
+    * `value` - The value to store.
+  """
+  @spec assign_auix(Phoenix.LiveView.Socket.t(), atom, any) :: Phoenix.LiveView.Socket.t()
+  def assign_auix(socket, key, value) do
+    socket.assigns
+    |> Map.get(:_auix, %{})
+    |> Map.put(key, value)
+    |> then(&assign(socket, :_auix, &1))
+  end
 
-                parsed_opts
-                |> Map.get(:index_row_click, "#")
-                |> String.replace("[[entity]]", id)
-                |> then(&navigate/1)
-              end
+  @doc """
+  Generates a link for showing an entity in the index view.
 
-          assign_auix(socket, :index_row_click, index_row_click)
-        end
+  ## Parameters
+    * `auix` - The auix configuration map containing :index_show_entity_link.
+    * `entity` - The entity map containing the :id field.
+  """
+  @spec index_show_entity_link(map, map) :: binary
+  def index_show_entity_link(auix, entity) do
+    auix
+    |> Map.get(:index_show_entity_link, "#")
+    |> String.replace("[[entity]]", Map.get(entity, :id))
+    |> then(fn link -> URI.decode("/#{link}") end)
+  end
 
-        @spec assign_auix(Phoenix.LiveView.Socket.t(), atom, any) :: Phoenix.LiveView.Socket.t()
-        def assign_auix(socket, key, value) do
-          socket.assigns
-          |> Map.get(:_auix, %{})
-          |> Map.put(key, value)
-          |> then(&assign(socket, :_auix, &1))
-        end
+  @doc """
+  Generates a path string for related entities.
 
-        @spec index_show_entity_link(binary, map) :: binary
-        def index_show_entity_link(auix, entity) do
-          auix
-          |> Map.get(:index_show_entity_link, "#")
-          |> String.replace("[[entity]]", Map.get(entity, :id))
-          |> then(fn link -> URI.decode("/#{link}") end)
-        end
+  ## Parameters
+    * `source` - The source identifier.
+    * `auix_entity` - The entity map containing :id and owner key value.
+    * `related_key` - The key identifying the relation.
+    * `owner_key` - The key identifying the owner field.
+  """
+  @spec related_path(binary, map, atom, atom) :: binary
+  def related_path(_source, _auix_entity, nil, _owner_key), do: ""
+  def related_path(_source, _auix_entity, _related_key, nil), do: ""
+  def related_path(_source, %{id: nil}, _related_key, _owner_key), do: ""
 
-        def related_path(source, _auix_entity, nil, _owner_key), do: ""
-        def related_path(source, _auix_entity, _related_key, nil), do: ""
-        def related_path(source, %{id: nil}, _related_key, _owner_key), do: ""
+  def related_path(source, %{id: id} = auix_entity, related_key, owner_key) do
+    "source=#{source}/#{id}&related_key=#{related_key}&parent_id=#{Map.get(auix_entity, owner_key)}"
+  end
 
-        def related_path(source, %{id: id} = auix_entity, related_key, owner_key) do
-          "source=#{source}/#{id}&related_key=#{related_key}&parent_id=#{Map.get(auix_entity, owner_key)}"
-        end
+  def related_path(_parsed_opts, _auix_entity, _related_key, _owner_key), do: ""
 
-        def related_path(_parsed_opts, _auix_entity, _related_key, _owner_key), do: ""
+  ## Non imported
+  @doc false
+  @spec __maybe_set_related_to_new_entity__(
+          binary | nil,
+          Phoenix.LiveView.Socket.t(),
+          binary | nil,
+          struct
+        ) :: Phoenix.LiveView.Socket.t()
+  def __maybe_set_related_to_new_entity__(related_key, socket, parent_id, default)
+      when is_nil(related_key) or is_nil(parent_id),
+      do: assign(socket, :auix_entity, default)
 
-        ## Non imported
-        @doc false
-        @spec __maybe_set_related_to_new_entity__(
-                Phoenix.LiveView.Socket.t(),
-                binary | nil,
-                binary | nil,
-                struct
-              ) :: Phoenix.LiveView.Socket.t()
-        def __maybe_set_related_to_new_entity__(related_key, socket, parent_id, default)
-            when is_nil(related_key) or is_nil(parent_id),
-            do: assign(socket, :auix_entity, default)
+  def __maybe_set_related_to_new_entity__(related_key, socket, parent_id, default) do
+    default
+    |> struct(%{related_key => parent_id})
+    |> then(&assign(socket, :auix_entity, &1))
+  end
 
-        def __maybe_set_related_to_new_entity__(related_key, socket, parent_id, default) do
-          default
-          |> struct(%{related_key => parent_id})
-          |> then(&assign(socket, :auix_entity, &1))
-        end
+  @doc false
+  @spec __maybe_set_different_source_and_link__(
+          binary | nil,
+          Phoenix.LiveView.Socket.t(),
+          binary | nil
+        ) :: Phoenix.LiveView.Socket.t()
+  def __maybe_set_different_source_and_link__(nil, socket, default_source) do
+    socket
+    |> assign(:_auix_source, default_source)
+    |> assign(:_auix_source_link, "")
+  end
 
-        @spec __maybe_set_different_source_and_link__(
-                binary | nil,
-                Phoenix.LiveView.Socket.t(),
-                binary | nil
-              ) :: Phoenix.LiveView.Socket.t()
-        def __maybe_set_different_source_and_link__(nil, socket, default_source) do
-          socket
-          |> assign(:_auix_source, default_source)
-          |> assign(:_auix_source_link, "")
-        end
+  def __maybe_set_different_source_and_link__(source, socket, _default_source) do
+    socket
+    |> assign(:_auix_source, source)
+    |> assign(:_auix_source_link, "?source=#{source}")
+  end
 
-        def __maybe_set_different_source_and_link__(source, socket, _default_source) do
-          socket
-          |> assign(:_auix_source, source)
-          |> assign(:_auix_source_link, "?source=#{source}")
-        end
-
-        ## PRIVATE
-        @spec navigate(binary) :: JS.t()
-        defp navigate(uri) do
-          ~p"/#{uri}"
-          |> URI.decode()
-          |> JS.navigate()
-        end
-      end
-    end
+  ## PRIVATE
+  @spec navigate(binary) :: JS.t()
+  defp navigate(uri) do
+    "/#{uri}"
+    |> URI.decode()
+    |> JS.navigate()
   end
 end

--- a/lib/aurora_uix_web/templates/core/logic_modules_generator.ex
+++ b/lib/aurora_uix_web/templates/core/logic_modules_generator.ex
@@ -60,8 +60,6 @@ defmodule AuroraUixWeb.Templates.Core.LogicModulesGenerator do
   Transforms configuration into fully-functional, dynamically generated LiveView modules.
   """
 
-  alias AuroraUixWeb.Templates.Core.Helpers, as: AuroraCoreHelpers
-
   require Logger
 
   @doc """
@@ -133,7 +131,7 @@ defmodule AuroraUixWeb.Templates.Core.LogicModulesGenerator do
     index_module = module_name(modules, parsed_opts, ".Index")
     form_component = module_name(modules, parsed_opts, ".FormComponent")
     alias_form_component = Module.concat(["#{parsed_opts.module_name}FormComponent"])
-    core_helpers = AuroraUixWeb.Core.Helpers
+    core_helpers = AuroraUixWeb.Templates.Core.Helpers
 
     quote do
       defmodule unquote(index_module) do
@@ -230,7 +228,7 @@ defmodule AuroraUixWeb.Templates.Core.LogicModulesGenerator do
     form_component = module_name(modules, parsed_opts, ".FormComponent")
     alias_form_component = Module.concat(["#{parsed_opts.module_name}FormComponent"])
     components = AuroraUixWeb.Components.AuroraCoreComponents
-    core_helpers = AuroraUixWeb.Core.Helpers
+    core_helpers = AuroraUixWeb.Templates.Core.Helpers
 
     quote do
       defmodule unquote(show_module) do
@@ -307,7 +305,7 @@ defmodule AuroraUixWeb.Templates.Core.LogicModulesGenerator do
     update_function = parsed_opts.update_function
     create_function = parsed_opts.create_function
     form_component = module_name(modules, parsed_opts, ".FormComponent")
-    core_helpers = AuroraUixWeb.Core.Helpers
+    core_helpers = AuroraUixWeb.Templates.Core.Helpers
 
     quote do
       defmodule unquote(form_component) do
@@ -402,10 +400,6 @@ defmodule AuroraUixWeb.Templates.Core.LogicModulesGenerator do
         defp notify_parent(msg), do: send(self(), {__MODULE__, msg})
       end
     end
-  end
-
-  def generate_module(modules, :aurora_core_helpers = type, parsed_opts) do
-    AuroraCoreHelpers.generate_module(modules, type, parsed_opts)
   end
 
   def generate_module(_modules, type, _parsed_opts) do

--- a/lib/aurora_uix_web/uix/create_ui.ex
+++ b/lib/aurora_uix_web/uix/create_ui.ex
@@ -147,13 +147,9 @@ defmodule AuroraUixWeb.Uix.CreateUI do
   """
   @spec build_ui(any, map, list, keyword) :: list
   def build_ui(caller, resource_configs, layout_paths, opts) do
-    {web, _} = caller |> Module.split() |> List.first() |> Code.eval_string()
-    template = Template.uix_template()
-
     resource_configs
     |> filter_resources(opts[:for])
     |> build_resources_layouts(caller, layout_paths, opts)
-    |> build_common_components(web, template)
   end
 
   ## PRIVATE
@@ -290,24 +286,6 @@ defmodule AuroraUixWeb.Uix.CreateUI do
   end
 
   defp build_resource_layouts(%{}, _caller), do: []
-
-  @spec build_common_components(list, module, module) :: list
-  defp build_common_components(uis, web, template) do
-    Enum.reduce(
-      template.common_modules(),
-      uis,
-      &maybe_build_common_component(web, template, &1, &2)
-    )
-  end
-
-  @spec maybe_build_common_component(module, module, tuple, list) :: Macro.t()
-  defp maybe_build_common_component(web, template, {type, module}, uis) do
-    if Code.loaded?(module) do
-      uis
-    else
-      [template.generate_module(%{web: web}, type) | uis]
-    end
-  end
 
   @spec parse_template_paths(tuple, map, map, module) :: tuple
   defp parse_template_paths({tag, key}, paths, parsed_opts, template) do


### PR DESCRIPTION
- Remove common modules generation and from the template callback
- Modify logic modules generator to use the new Helpers.