### PR TITLE
Renaming of AuroraUix and AuroraUixWeb domains

### DIFF
--- a/.doctor.exs
+++ b/.doctor.exs
@@ -1,5 +1,5 @@
 %Doctor.Config{
-  ignore_modules: [AuroraUixWeb.Templates.Base, AuroraUixWeb.Gettext, AuroraUixWeb.Uix.DataConfigUI, AuroraUix.ResourceRegistration],
+  ignore_modules: [Aurora.Uix.Web.Templates.Base, Aurora.Uix.Web.Gettext, Aurora.Uix.Web.Uix.DataConfigUI, Aurora.Uix.ResourceRegistration],
   ignore_paths: [~r".+/-local-.*"],
   min_module_doc_coverage: 100,
   min_module_spec_coverage: 100,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Compatible with Phoenix LiveView v1.0+
   - `sections/3` - Group content in tab-like structures
 
 * UI Generation
-  - Compile-time UI generation through `use AuroraUixWeb.Uix.CreateUI`
+  - Compile-time UI generation through `use Aurora.Uix.Web.Uix.CreateUI`
   - Dynamic template generation with HEEx support
   - Integrated i18n support via configurable Gettext backend
 

--- a/lib/aurora_uix/field.ex
+++ b/lib/aurora_uix/field.ex
@@ -1,6 +1,6 @@
-defmodule AuroraUix.Field do
+defmodule Aurora.Uix.Field do
   @moduledoc """
-  A module representing a configurable field in the AuroraUix system.
+  A module representing a configurable field in the Aurora.Uix system.
 
   This module defines a struct to represent field properties for UI components, such as:
     - `field` (`atom`) - The field reference in the schema.
@@ -67,7 +67,7 @@ defmodule AuroraUix.Field do
         }
 
   @doc """
-  Creates a new `%AuroraUix.Field{}` struct with the given attributes.
+  Creates a new `%Aurora.Uix.Field{}` struct with the given attributes.
 
     ## Parameters
 
@@ -76,8 +76,8 @@ defmodule AuroraUix.Field do
 
   ## Examples
 
-      iex> AuroraUix.Field.new(%{field: :age, field_type: :float, field_html_type: :float, precision: 10, scale: 2})
-      %AuroraUix.Field{
+      iex> Aurora.Uix.Field.new(%{field: :age, field_type: :float, field_html_type: :float, precision: 10, scale: 2})
+      %Aurora.Uix.Field{
         field: :age,
         field_type: :float,
         field_html_type: :float,
@@ -98,8 +98,8 @@ defmodule AuroraUix.Field do
       }
 
 
-      iex> AuroraUix.Field.new([field: :username, field_type: :binary, field_html_type: :text])
-      %AuroraUix.Field{
+      iex> Aurora.Uix.Field.new([field: :username, field_type: :binary, field_html_type: :text])
+      %Aurora.Uix.Field{
         field: :username,
         field_type: :binary,
         field_html_type: :text,
@@ -123,7 +123,7 @@ defmodule AuroraUix.Field do
   def new(attrs \\ %{}), do: change(%__MODULE__{}, attrs)
 
   @doc """
-  Updates an existing `%AuroraUix.Field{}` struct with new attributes.
+  Updates an existing `%Aurora.Uix.Field{}` struct with new attributes.
 
     ## Parameters
 
@@ -133,8 +133,8 @@ defmodule AuroraUix.Field do
 
     ## Examples
 
-        iex> field = AuroraUix.Field.new(%{field: :age})
-        %AuroraUix.Field{
+        iex> field = Aurora.Uix.Field.new(%{field: :age})
+        %Aurora.Uix.Field{
           field: :age,
           field_type: nil,
           field_html_type: nil,
@@ -153,8 +153,8 @@ defmodule AuroraUix.Field do
           disabled: false,
           omitted: false
         }
-        iex> AuroraUix.Field.change(field, %{field_html_type: :number, precision: 3})
-        %AuroraUix.Field{
+        iex> Aurora.Uix.Field.change(field, %{field_html_type: :number, precision: 3})
+        %Aurora.Uix.Field{
           field: :age,
           field_type: nil,
           field_html_type: :number,

--- a/lib/aurora_uix/parser.ex
+++ b/lib/aurora_uix/parser.ex
@@ -1,9 +1,9 @@
-defmodule AuroraUix.Parser do
+defmodule Aurora.Uix.Parser do
   @moduledoc """
   Provides parsing utilities for transforming schema modules into configuration maps for UI rendering.
 
   This module serves as the primary interface for converting Ecto schema modules into structured
-  configuration maps, enabling dynamic UI generation across the AuroraUix system.
+  configuration maps, enabling dynamic UI generation across the Aurora.Uix system.
 
   Key responsibilities:
   - Extract metadata from schema modules
@@ -11,9 +11,9 @@ defmodule AuroraUix.Parser do
   - Prepare configuration maps for different UI views (index, form, etc.)
   """
 
-  alias AuroraUix.Parsers.Common
-  alias AuroraUix.Parsers.ContextParser
-  alias AuroraUix.Parsers.IndexParser
+  alias Aurora.Uix.Parsers.Common
+  alias Aurora.Uix.Parsers.ContextParser
+  alias Aurora.Uix.Parsers.IndexParser
 
   @callback default_value(parsed_opts :: map, resource_config :: map, key :: atom) :: any
 
@@ -23,9 +23,9 @@ defmodule AuroraUix.Parser do
   ## Parameters
     - `resource_config` (map) - contains all the modules' configuration.
     - `opts` (keyword) - Configuration options. See full list in:
-      - Common options: `AuroraUix.Parsers.Common.parse/3`
-      - Index-specific options: `AuroraUix.Parsers.IndexParser.parse/3`
-      - Context specific options: `AuroraUix.Parsers.ContextParser.parse/3`
+      - Common options: `Aurora.Uix.Parsers.Common.parse/3`
+      - Index-specific options: `Aurora.Uix.Parsers.IndexParser.parse/3`
+      - Context specific options: `Aurora.Uix.Parsers.ContextParser.parse/3`
 
   ## Returns
   A map containing:
@@ -41,7 +41,7 @@ defmodule AuroraUix.Parser do
   ...>     field :reference, :string
   ...>   end
   ...> end
-  iex> AuroraUix.Parser.parse(%{schema: MySchema})
+  iex> Aurora.Uix.Parser.parse(%{schema: MySchema})
   %{
     module: "my_schema",
     module_name: "MySchema",

--- a/lib/aurora_uix/parsers/common.ex
+++ b/lib/aurora_uix/parsers/common.ex
@@ -1,4 +1,4 @@
-defmodule AuroraUix.Parsers.Common do
+defmodule Aurora.Uix.Parsers.Common do
   @moduledoc """
   Handles common parsing logic for extracting metadata from Ecto schema modules.
 
@@ -10,7 +10,7 @@ defmodule AuroraUix.Parsers.Common do
   Supports a wide range of configuration options for customizing UI generation.
   """
 
-  use AuroraUix.Parsers.ParserCore
+  use Aurora.Uix.Parsers.ParserCore
 
   @doc """
   Extracts schema metadata and merges common options.
@@ -34,8 +34,8 @@ defmodule AuroraUix.Parsers.Common do
       Uses the function __schema__/1 passing :source as the argument.
     - `sub_title` -  Subtitle for the view, a :hide value will disallow its generation.
     - `template` -  Overrides the module that handles the generation.
-      By default, uses AuroraUixWeb.AuroraTemplate, which is a sophisticated and highly opinionated template.
-      There is also the AuroraUixWeb.PhoenixTemplate, which resembles the phoenix ui.
+      By default, uses Aurora.Uix.Web.AuroraTemplate, which is a sophisticated and highly opinionated template.
+      There is also the Aurora.Uix.Web.PhoenixTemplate, which resembles the phoenix ui.
       The template can also be configured, application wide, by adding :aurora_uix, template: Module.
       New templates can be authored.
     - `title` -  Title for the UI. Uses the capitalized schema source as the title.
@@ -50,8 +50,8 @@ defmodule AuroraUix.Parsers.Common do
       Title: "Account receivables"
 
   ## Example
-    iex> alias AuroraUix.Parsers.Common
-    iex> defmodule AuroraUix.GeneralLedger.Account do
+    iex> alias Aurora.Uix.Parsers.Common
+    iex> defmodule Aurora.Uix.GeneralLedger.Account do
     ...>    use Ecto.Schema
     ...>    schema "accounts" do
     ...>      field :description, :string
@@ -59,13 +59,13 @@ defmodule AuroraUix.Parsers.Common do
     ...>      timestamps()
     ...>    end
     ...>  end
-    iex> parsed = Common.parse(%{}, %{schema: AuroraUix.GeneralLedger.Account}, [])
+    iex> parsed = Common.parse(%{}, %{schema: Aurora.Uix.GeneralLedger.Account}, [])
     iex> parsed.name == "Account" # Name is taken from last part of the schema module name
     true
     iex> parsed.title == "Accounts" # Uses the capitalized schema source as the title.
 
-    iex> alias AuroraUix.Parsers.Common
-    iex> defmodule AuroraUix.GeneralLedger.AccountReceivable do
+    iex> alias Aurora.Uix.Parsers.Common
+    iex> defmodule Aurora.Uix.GeneralLedger.AccountReceivable do
     ...>   use Ecto.Schema
     ...>   schema "account_receivables" do
     ...>     field :description, :string
@@ -73,7 +73,7 @@ defmodule AuroraUix.Parsers.Common do
     ...>     timestamps()
     ...>   end
     ...> end
-    iex> parsed = Common.parse(%{}, %{schema: AuroraUix.GeneralLedger.AccountReceivable}, [])
+    iex> parsed = Common.parse(%{}, %{schema: Aurora.Uix.GeneralLedger.AccountReceivable}, [])
     iex> parsed.title == "Account Receivables"  # Uses the capitalized schema source as the title
   """
   @spec parse(map, map, keyword) :: map

--- a/lib/aurora_uix/parsers/context_parser.ex
+++ b/lib/aurora_uix/parsers/context_parser.ex
@@ -1,4 +1,4 @@
-defmodule AuroraUix.Parsers.ContextParser do
+defmodule Aurora.Uix.Parsers.ContextParser do
   @moduledoc """
   Provides parsing functionality for context-based resource configurations in Elixir applications.
 
@@ -29,7 +29,7 @@ defmodule AuroraUix.Parsers.ContextParser do
 
       parsed_opts = ContextParser.parse(%{}, resource_config)
   """
-  use AuroraUix.Parsers.ParserCore
+  use Aurora.Uix.Parsers.ParserCore
 
   @doc """
     Parse module and :index options.

--- a/lib/aurora_uix/parsers/index_parser.ex
+++ b/lib/aurora_uix/parsers/index_parser.ex
@@ -1,6 +1,6 @@
-defmodule AuroraUix.Parsers.IndexParser do
+defmodule Aurora.Uix.Parsers.IndexParser do
   @moduledoc """
-  Specializes in parsing index and card-related configuration options for AuroraUix UI components.
+  Specializes in parsing index and card-related configuration options for Aurora.Uix UI components.
 
   Handles specific parsing requirements for:
   - Defining rows and data sources
@@ -10,7 +10,7 @@ defmodule AuroraUix.Parsers.IndexParser do
   Extends the base parsing behavior with index-specific logic.
   """
 
-  use AuroraUix.Parsers.ParserCore
+  use Aurora.Uix.Parsers.ParserCore
 
   @doc """
   Parse module and :index options.

--- a/lib/aurora_uix/parsers/parser_core.ex
+++ b/lib/aurora_uix/parsers/parser_core.ex
@@ -1,6 +1,6 @@
-defmodule AuroraUix.Parsers.ParserCore do
+defmodule Aurora.Uix.Parsers.ParserCore do
   @moduledoc """
-  Provides a base implementation and macro for parser behaviors in the AuroraUix system.
+  Provides a base implementation and macro for parser behaviors in the Aurora.Uix system.
 
   This module defines common utilities and macros used across different parser modules,
   including:
@@ -15,7 +15,7 @@ defmodule AuroraUix.Parsers.ParserCore do
 
   defmacro __using__(_opts) do
     quote do
-      @behaviour AuroraUix.Parser
+      @behaviour Aurora.Uix.Parser
 
       @spec add_opt(map, map, keyword, atom) :: map
       defp add_opt(parsed_opts, resource_config, opts, key) do

--- a/lib/aurora_uix/resource_config_ui.ex
+++ b/lib/aurora_uix/resource_config_ui.ex
@@ -1,4 +1,4 @@
-defmodule AuroraUix.ResourceConfigUI do
+defmodule Aurora.Uix.ResourceConfigUI do
   @moduledoc """
   Manages comprehensive metadata configuration for schemas and their associated UI representations.
 
@@ -10,9 +10,9 @@ defmodule AuroraUix.ResourceConfigUI do
   Key features:
   - Supports custom field configurations
   - Allows runtime modification of schema metadata
-  - Integrates with other AuroraUix parsing components
+  - Integrates with other Aurora.Uix parsing components
   """
-  alias AuroraUix.Field
+  alias Aurora.Uix.Field
 
   defstruct [:name, :schema, :context, fields: [], fields_order: []]
 
@@ -24,7 +24,7 @@ defmodule AuroraUix.ResourceConfigUI do
         }
 
   @doc """
-  Creates a new `AuroraUix.ResourceConfigUI` struct with the given attributes.
+  Creates a new `Aurora.Uix.ResourceConfigUI` struct with the given attributes.
 
   ## Parameters
 
@@ -33,16 +33,16 @@ defmodule AuroraUix.ResourceConfigUI do
 
   ## Examples
 
-      iex> AuroraUix.ResourceConfigUI.new()
-      %AuroraUix.ResourceConfigUI{name: nil, schema: nil, context: nil, fields: []}
+      iex> Aurora.Uix.ResourceConfigUI.new()
+      %Aurora.Uix.ResourceConfigUI{name: nil, schema: nil, context: nil, fields: []}
 
-      iex> AuroraUix.ResourceConfigUI.new(%{name: :my_schema, schema: MySchema, fields: [AuroraUix.Field.new(field: :custom_field)]})
-      %AuroraUix.ResourceConfigUI{
+      iex> Aurora.Uix.ResourceConfigUI.new(%{name: :my_schema, schema: MySchema, fields: [Aurora.Uix.Field.new(field: :custom_field)]})
+      %Aurora.Uix.ResourceConfigUI{
         name: :my_schema,
         schema: MySchema,
         context: nil,
         fields: [
-          %AuroraUix.Field{
+          %Aurora.Uix.Field{
             field: :custom_field,
             field_type: nil,
             renderer: nil,
@@ -66,30 +66,30 @@ defmodule AuroraUix.ResourceConfigUI do
   def new(attrs \\ %{}), do: change(%__MODULE__{}, attrs)
 
   @doc """
-  Updates an existing `AuroraUix.ResourceConfigUI` struct with the given attributes.
+  Updates an existing `Aurora.Uix.ResourceConfigUI` struct with the given attributes.
 
   ## Parameters
 
-  - `metadata`: The existing `AuroraUix.ResourceConfigUI` struct to be updated.
+  - `metadata`: The existing `Aurora.Uix.ResourceConfigUI` struct to be updated.
   - `attrs`: A map or keyword containing the attributes to update the metadata.
     The allowed keys are `:name`, `:schema`, `:context`, and `:fields`.
 
   ## Examples
 
-      iex> metadata = %AuroraUix.ResourceConfigUI{name: :my_schema, schema: MySchema, context: MyContext}
-      %AuroraUix.ResourceConfigUI{
+      iex> metadata = %Aurora.Uix.ResourceConfigUI{name: :my_schema, schema: MySchema, context: MyContext}
+      %Aurora.Uix.ResourceConfigUI{
           name: :my_schema,
           schema: MySchema,
         context: MyContext,
         fields: []
       }
-      iex> AuroraUix.ResourceConfigUI.change(metadata, context: nil, fields: [AuroraUix.Field.new(field: :reference)])
-      %AuroraUix.ResourceConfigUI{
+      iex> Aurora.Uix.ResourceConfigUI.change(metadata, context: nil, fields: [Aurora.Uix.Field.new(field: :reference)])
+      %Aurora.Uix.ResourceConfigUI{
         name: :my_schema,
         schema: MySchema,
         context: nil,
         fields: [
-          %AuroraUix.Field{
+          %Aurora.Uix.Field{
             field: :reference,
             field_type: nil,
             renderer: nil,
@@ -109,13 +109,13 @@ defmodule AuroraUix.ResourceConfigUI do
         ]
       }
 
-      iex> metadata = %AuroraUix.ResourceConfigUI{name: :my_schema, schema: MySchema, fields: [AuroraUix.Field.new(field: :reference)]}
-      %AuroraUix.ResourceConfigUI{
+      iex> metadata = %Aurora.Uix.ResourceConfigUI{name: :my_schema, schema: MySchema, fields: [Aurora.Uix.Field.new(field: :reference)]}
+      %Aurora.Uix.ResourceConfigUI{
         name: :my_schema,
         schema: MySchema,
         context: nil,
         fields: [
-          %AuroraUix.Field{
+          %Aurora.Uix.Field{
             field: :reference,
             field_type: nil,
             renderer: nil,
@@ -134,13 +134,13 @@ defmodule AuroraUix.ResourceConfigUI do
           }
         ]
       }
-      iex> AuroraUix.ResourceConfigUI.change(metadata, context: MyContext, fields: [reference: %{label: "My reference"}, description: %{label: "My description"}])
-      %AuroraUix.ResourceConfigUI{
+      iex> Aurora.Uix.ResourceConfigUI.change(metadata, context: MyContext, fields: [reference: %{label: "My reference"}, description: %{label: "My description"}])
+      %Aurora.Uix.ResourceConfigUI{
         name: :my_schema,
         schema: MySchema,
         context: MyContext,
         fields: [
-          %AuroraUix.Field{
+          %Aurora.Uix.Field{
             field: :reference,
             field_type: nil,
             renderer: nil,
@@ -157,7 +157,7 @@ defmodule AuroraUix.ResourceConfigUI do
             disabled: false,
             omitted: false
           },
-          %AuroraUix.Field{
+          %Aurora.Uix.Field{
             field: :description,
             field_type: nil,
             renderer: nil,

--- a/lib/aurora_uix_web/core_components.ex
+++ b/lib/aurora_uix_web/core_components.ex
@@ -1,10 +1,10 @@
-defmodule AuroraUixWeb.CoreComponents do
+defmodule Aurora.Uix.Web.CoreComponents do
   @moduledoc """
   This module provides core components for the Aurora Uix web application.
   It includes helper functions and macros for building UI components
   and templates using Phoenix LiveView.
   """
-  alias AuroraUixWeb.Template
+  alias Aurora.Uix.Web.Template
 
   @spec __using__(keyword) :: Macro.t()
   @doc """

--- a/lib/aurora_uix_web/gettext.ex
+++ b/lib/aurora_uix_web/gettext.ex
@@ -1,4 +1,4 @@
-defmodule AuroraUixWeb.Gettext do
+defmodule Aurora.Uix.Web.Gettext do
   @moduledoc """
   Provides dynamic gettext functionality where the backend is determined by an environment variable.
   """
@@ -8,18 +8,18 @@ defmodule AuroraUixWeb.Gettext do
 
   ## Options
 
-    * `:backend` - The Gettext backend module to use. Defaults to AuroraUixWeb.GettextBackend
+    * `:backend` - The Gettext backend module to use. Defaults to Aurora.Uix.Web.GettextBackend
 
   ## Examples
 
       # Basic usage with default backend
       defmodule MyApp.Gettext do
-        use AuroraUixWeb.Gettext
+        use Aurora.Uix.Web.Gettext
       end
 
       # With custom backend
       defmodule MyApp.Gettext do
-        use AuroraUixWeb.Gettext, backend: MyCustomBackend
+        use Aurora.Uix.Web.Gettext, backend: MyCustomBackend
       end
 
       # Usage in runtime
@@ -31,7 +31,7 @@ defmodule AuroraUixWeb.Gettext do
   """
   @spec __using__(keyword) :: Macro.t()
   defmacro __using__(opts) do
-    default_backend = opts[:backend] || AuroraUixWeb.GettextBackend
+    default_backend = opts[:backend] || Aurora.Uix.Web.GettextBackend
 
     backend_module =
       Application.get_env(:aurora_uix, :gettext_backend, default_backend)

--- a/lib/aurora_uix_web/gettext_backend.ex
+++ b/lib/aurora_uix_web/gettext_backend.ex
@@ -1,4 +1,4 @@
-defmodule AuroraUixWeb.GettextBackend do
+defmodule Aurora.Uix.Web.GettextBackend do
   @moduledoc """
   A fallback module that provides Internationalization with a gettext-based API.
   """

--- a/lib/aurora_uix_web/template.ex
+++ b/lib/aurora_uix_web/template.ex
@@ -1,4 +1,4 @@
-defmodule AuroraUixWeb.Template do
+defmodule Aurora.Uix.Web.Template do
   @moduledoc """
   A core module for template generation and management in Aurora UIX, providing a standardized
   behavior and utility functions for creating dynamic UI templates.
@@ -81,7 +81,7 @@ defmodule AuroraUixWeb.Template do
   ```
   """
 
-  @uix_template Application.compile_env(:aurora_uix, :template, AuroraUixWeb.Templates.Core)
+  @uix_template Application.compile_env(:aurora_uix, :template, Aurora.Uix.Web.Templates.Core)
 
   @doc """
   Generates a HTML code fragment for the specified mode and options.
@@ -136,7 +136,7 @@ defmodule AuroraUixWeb.Template do
   ## Parameters
 
   - `path` (map): Contains the relevant information for a layout path.
-    See `AuroraUixWeb.Uix.LayoutConfigUI` for details on the path structure.
+    See `Aurora.Uix.Web.Uix.LayoutConfigUI` for details on the path structure.
   - `configurations` (map): contains the overall configuration for all resources.
   - `parsed_opts` (map): Additional parsing options
   - `resource_name` (atom): Name of the resource that is going to be processed.
@@ -167,7 +167,7 @@ defmodule AuroraUixWeb.Template do
     - `parsed_options` (map): Options to use.
 
   ## Examples
-    iex> AuroraUixWeb.Template.build_html(%{title: "Aurora UIX builder"},
+    iex> Aurora.Uix.Web.Template.build_html(%{title: "Aurora UIX builder"},
     ... ~S\"""
     ... This application: [[title]]
     ... \""")

--- a/lib/aurora_uix_web/templates/core.ex
+++ b/lib/aurora_uix_web/templates/core.ex
@@ -1,4 +1,4 @@
-defmodule AuroraUixWeb.Templates.Core do
+defmodule Aurora.Uix.Web.Templates.Core do
   @moduledoc """
   A centralized module for coordinating template generation processes in Aurora UIX,
   serving as the primary entry point for template-related functionality.
@@ -10,7 +10,7 @@ defmodule AuroraUixWeb.Templates.Core do
   - `MarkupGenerator`: Creates HEEx template fragments
 
   ## Responsibilities
-  - Implement the `AuroraUixWeb.Template` behavior
+  - Implement the `Aurora.Uix.Web.Template` behavior
   - Coordinate between different template generation components
   - Provide a unified interface for template creation
 
@@ -28,17 +28,17 @@ defmodule AuroraUixWeb.Templates.Core do
   ## Usage Example
   ```elixir
   # Automatic delegation happens through the Template behavior
-  AuroraUixWeb.Templates.Core.generate_view(:index, %{fields: [:name, :email]})
+  Aurora.Uix.Web.Templates.Core.generate_view(:index, %{fields: [:name, :email]})
   ```
   The module ensures a clean separation of concerns while providing a streamlined
   template generation process for different UI components.
   """
-  @behaviour AuroraUixWeb.Template
+  @behaviour Aurora.Uix.Web.Template
 
-  alias AuroraUix.Field
-  alias AuroraUixWeb.Templates.Core.LayoutParser
-  alias AuroraUixWeb.Templates.Core.LogicModulesGenerator
-  alias AuroraUixWeb.Templates.Core.MarkupGenerator
+  alias Aurora.Uix.Field
+  alias Aurora.Uix.Web.Templates.Core.LayoutParser
+  alias Aurora.Uix.Web.Templates.Core.LogicModulesGenerator
+  alias Aurora.Uix.Web.Templates.Core.MarkupGenerator
 
   @doc """
   Parses the layout configuration for template generation.
@@ -96,7 +96,7 @@ defmodule AuroraUixWeb.Templates.Core do
   """
   @spec default_core_components() :: module
   def default_core_components do
-    AuroraUixWeb.Templates.Core.CoreComponents
+    Aurora.Uix.Web.Templates.Core.CoreComponents
   end
 
   @doc """

--- a/lib/aurora_uix_web/templates/core/components/core_components.ex
+++ b/lib/aurora_uix_web/templates/core/components/core_components.ex
@@ -1,4 +1,4 @@
-defmodule AuroraUixWeb.Templates.Core.CoreComponents do
+defmodule Aurora.Uix.Web.Templates.Core.CoreComponents do
   @moduledoc """
   Provides core UI components.
 
@@ -14,7 +14,7 @@ defmodule AuroraUixWeb.Templates.Core.CoreComponents do
 
   Icons are provided by [heroicons](https://heroicons.com). See `icon/1` for usage.
   """
-  use AuroraUixWeb.Gettext
+  use Aurora.Uix.Web.Gettext
   use Phoenix.Component
 
   alias Phoenix.HTML.Form

--- a/lib/aurora_uix_web/templates/core/components/live/aurora_index_list.ex
+++ b/lib/aurora_uix_web/templates/core/components/live/aurora_index_list.ex
@@ -1,4 +1,4 @@
-defmodule AuroraUixWeb.Templates.Core.Components.Live.AuroraIndexList do
+defmodule Aurora.Uix.Web.Templates.Core.Components.Live.AuroraIndexList do
   @moduledoc """
   A specialized index list LiveComponent for displaying tabular data.
 
@@ -23,7 +23,7 @@ defmodule AuroraUixWeb.Templates.Core.Components.Live.AuroraIndexList do
   """
 
   use Phoenix.LiveComponent
-  use AuroraUixWeb.CoreComponents
+  use Aurora.Uix.Web.CoreComponents
 
   @impl true
   def update(assigns, socket) do

--- a/lib/aurora_uix_web/templates/core/helpers.ex
+++ b/lib/aurora_uix_web/templates/core/helpers.ex
@@ -1,4 +1,4 @@
-defmodule AuroraUixWeb.Templates.Core.Helpers do
+defmodule Aurora.Uix.Web.Templates.Core.Helpers do
   @moduledoc """
   Helper functions for LiveView components.
   """
@@ -6,7 +6,7 @@ defmodule AuroraUixWeb.Templates.Core.Helpers do
   use Phoenix.Component
   use Phoenix.LiveComponent
 
-  import AuroraUixWeb.Template, only: [safe_existing_atom: 1]
+  import Aurora.Uix.Web.Template, only: [safe_existing_atom: 1]
 
   alias Phoenix.LiveView.JS
 

--- a/lib/aurora_uix_web/templates/core/layout_parser.ex
+++ b/lib/aurora_uix_web/templates/core/layout_parser.ex
@@ -1,4 +1,4 @@
-defmodule AuroraUixWeb.Templates.Core.LayoutParser do
+defmodule Aurora.Uix.Web.Templates.Core.LayoutParser do
   @moduledoc """
   Advanced layout parsing and rendering system for dynamic UI template generation.
 
@@ -44,8 +44,8 @@ defmodule AuroraUixWeb.Templates.Core.LayoutParser do
   - Consistent UI generation
   - Extensible field handling
   """
-  import AuroraUixWeb.Templates.Core, only: [get_field: 3]
-  alias AuroraUixWeb.Templates.Core.Markups
+  import Aurora.Uix.Web.Templates.Core, only: [get_field: 3]
+  alias Aurora.Uix.Web.Templates.Core.Markups
 
   @doc """
   Parses layout configurations and generates corresponding HTML structure.
@@ -247,17 +247,18 @@ defmodule AuroraUixWeb.Templates.Core.LayoutParser do
 
   # Renders individual fields
   # Skip disabled fields
-  @spec render_field(AuroraUix.Field.t(), map, map, atom) :: binary
-  defp render_field(%AuroraUix.Field{omitted: true}, _configurations, _parsed_opts, _mode), do: ""
+  @spec render_field(Aurora.Uix.Field.t(), map, map, atom) :: binary
+  defp render_field(%Aurora.Uix.Field{omitted: true}, _configurations, _parsed_opts, _mode),
+    do: ""
 
-  defp render_field(%AuroraUix.Field{} = field, configurations, parsed_opts, mode) do
+  defp render_field(%Aurora.Uix.Field{} = field, configurations, parsed_opts, mode) do
     case field.renderer do
       custom_renderer when is_function(custom_renderer, 1) -> custom_renderer.(field)
       _ -> default_field_render(field, configurations, parsed_opts, mode)
     end
   end
 
-  @spec default_field_render(AuroraUix.Field.t(), map, map, atom) :: binary
+  @spec default_field_render(Aurora.Uix.Field.t(), map, map, atom) :: binary
 
   defp default_field_render(
          %{field_type: :one_to_many_association, resource: nil} = _field,
@@ -297,7 +298,7 @@ defmodule AuroraUixWeb.Templates.Core.LayoutParser do
 
     ~s"""
       <.live_component
-        module={AuroraUixWeb.Templates.Core.Components.Live.AuroraIndexList}
+        module={Aurora.Uix.Web.Templates.Core.Components.Live.AuroraIndexList}
         id="auix-#{parsed_opts.name}__#{field.field}"
         title="#{related_parsed_opts.title} Elements"
         module_name="#{related_parsed_opts.title}"
@@ -347,7 +348,7 @@ defmodule AuroraUixWeb.Templates.Core.LayoutParser do
     do_default_field_render(field, opts, parsed_opts, mode)
   end
 
-  @spec do_default_field_render(AuroraUix.Field.t(), map, map, atom) :: binary
+  @spec do_default_field_render(Aurora.Uix.Field.t(), map, map, atom) :: binary
   defp do_default_field_render(%{hidden: true} = field, opts, _parsed_opts, :form = mode),
     do:
       ~s(<input type="hidden" id="#{opts.id}-#{mode}" name={@form[:#{field.field}].name} value={@form[:#{field.field}].value}  />)

--- a/lib/aurora_uix_web/templates/core/logic_modules_generator.ex
+++ b/lib/aurora_uix_web/templates/core/logic_modules_generator.ex
@@ -1,4 +1,4 @@
-defmodule AuroraUixWeb.Templates.Core.LogicModulesGenerator do
+defmodule Aurora.Uix.Web.Templates.Core.LogicModulesGenerator do
   @moduledoc """
   Dynamic LiveView module generator for creating CRUD-oriented user interfaces.
 
@@ -131,7 +131,7 @@ defmodule AuroraUixWeb.Templates.Core.LogicModulesGenerator do
     index_module = module_name(modules, parsed_opts, ".Index")
     form_component = module_name(modules, parsed_opts, ".FormComponent")
     alias_form_component = Module.concat(["#{parsed_opts.module_name}FormComponent"])
-    core_helpers = AuroraUixWeb.Templates.Core.Helpers
+    core_helpers = Aurora.Uix.Web.Templates.Core.Helpers
 
     quote do
       defmodule unquote(index_module) do
@@ -140,7 +140,7 @@ defmodule AuroraUixWeb.Templates.Core.LogicModulesGenerator do
         use unquote(modules.web), :live_view
 
         import unquote(core_helpers)
-        import AuroraUixWeb.Template, only: [compile_heex: 2]
+        import Aurora.Uix.Web.Template, only: [compile_heex: 2]
 
         alias unquote(modules.context)
         alias unquote(modules.module)
@@ -227,8 +227,8 @@ defmodule AuroraUixWeb.Templates.Core.LogicModulesGenerator do
     show_module = module_name(modules, parsed_opts, ".Show")
     form_component = module_name(modules, parsed_opts, ".FormComponent")
     alias_form_component = Module.concat(["#{parsed_opts.module_name}FormComponent"])
-    components = AuroraUixWeb.Components.AuroraCoreComponents
-    core_helpers = AuroraUixWeb.Templates.Core.Helpers
+    components = Aurora.Uix.Web.Components.AuroraCoreComponents
+    core_helpers = Aurora.Uix.Web.Templates.Core.Helpers
 
     quote do
       defmodule unquote(show_module) do
@@ -237,7 +237,7 @@ defmodule AuroraUixWeb.Templates.Core.LogicModulesGenerator do
         use unquote(modules.web), :live_view
 
         import unquote(core_helpers)
-        import AuroraUixWeb.Template, only: [compile_heex: 2]
+        import Aurora.Uix.Web.Template, only: [compile_heex: 2]
 
         alias unquote(modules.context)
         alias unquote(modules.module)
@@ -305,7 +305,7 @@ defmodule AuroraUixWeb.Templates.Core.LogicModulesGenerator do
     update_function = parsed_opts.update_function
     create_function = parsed_opts.create_function
     form_component = module_name(modules, parsed_opts, ".FormComponent")
-    core_helpers = AuroraUixWeb.Templates.Core.Helpers
+    core_helpers = Aurora.Uix.Web.Templates.Core.Helpers
 
     quote do
       defmodule unquote(form_component) do
@@ -314,7 +314,7 @@ defmodule AuroraUixWeb.Templates.Core.LogicModulesGenerator do
         use unquote(modules.web), :live_component
 
         import unquote(core_helpers)
-        import AuroraUixWeb.Template, only: [compile_heex: 2]
+        import Aurora.Uix.Web.Template, only: [compile_heex: 2]
 
         alias unquote(modules.context)
 

--- a/lib/aurora_uix_web/templates/core/markup_generator.ex
+++ b/lib/aurora_uix_web/templates/core/markup_generator.ex
@@ -1,4 +1,4 @@
-defmodule AuroraUixWeb.Templates.Core.MarkupGenerator do
+defmodule Aurora.Uix.Web.Templates.Core.MarkupGenerator do
   @moduledoc """
   Responsible for generating standardized HEEx template fragments for different UI component types.
 
@@ -33,13 +33,13 @@ defmodule AuroraUixWeb.Templates.Core.MarkupGenerator do
   ## Examples
 
   ```elixir
-  iex> AuroraUixWeb.Templates.Core.MarkupGenerator.generate_view(:index, %{})
+  iex> Aurora.Uix.Web.Templates.Core.MarkupGenerator.generate_view(:index, %{})
   # => "<h1>Base Template</h1>list"
 
-  iex> AuroraUixWeb.Templates.Core.MarkupGenerator.generate_view(:index, %{})
+  iex> Aurora.Uix.Web.Templates.Core.MarkupGenerator.generate_view(:index, %{})
   # => "<h1>Base Template</h1>card"
 
-  iex> AuroraUixWeb.Templates.Core.MarkupGenerator.generate_view(:form, %{})
+  iex> Aurora.Uix.Web.Templates.Core.MarkupGenerator.generate_view(:form, %{})
   # => "<h1>Base Template</h1>form"
   ```
 
@@ -47,7 +47,7 @@ defmodule AuroraUixWeb.Templates.Core.MarkupGenerator do
   with minimal manual intervention.
   """
 
-  alias AuroraUixWeb.Template
+  alias Aurora.Uix.Web.Template
 
   @doc """
   Generates a HEEx template fragment for the specified UI component type.
@@ -81,7 +81,7 @@ defmodule AuroraUixWeb.Templates.Core.MarkupGenerator do
       parsed_opts,
       ~S"""
         <.live_component
-          module={AuroraUixWeb.Templates.Core.Components.Live.AuroraIndexList}
+          module={Aurora.Uix.Web.Templates.Core.Components.Live.AuroraIndexList}
           id="[[source]]"
           title="Listing [[title]]"
           module_name="[[title]]"

--- a/lib/aurora_uix_web/templates/core/markups/form_layout.ex
+++ b/lib/aurora_uix_web/templates/core/markups/form_layout.ex
@@ -1,13 +1,13 @@
-defmodule AuroraUixWeb.Templates.Core.Markups.FormLayout do
+defmodule Aurora.Uix.Web.Templates.Core.Markups.FormLayout do
   @moduledoc """
   Provides functionality for generating form layout markup in HEEX templates.
   This module handles the parsing and generation of form containers with proper styling
   and structure according to the Aurora UI specifications.
   """
 
-  import AuroraUixWeb.Templates.Core, only: [parse_layout: 5]
+  import Aurora.Uix.Web.Templates.Core, only: [parse_layout: 5]
 
-  alias AuroraUixWeb.Template
+  alias Aurora.Uix.Web.Template
 
   @doc """
   Parses the form layout configuration and generates the corresponding HEEX markup.

--- a/lib/aurora_uix_web/templates/core/markups/index_layout.ex
+++ b/lib/aurora_uix_web/templates/core/markups/index_layout.ex
@@ -1,12 +1,12 @@
-defmodule AuroraUixWeb.Templates.Core.Markups.IndexLayout do
+defmodule Aurora.Uix.Web.Templates.Core.Markups.IndexLayout do
   @moduledoc """
   Provides functionality for generating index view layout markup in HEEX templates.
   This module handles the parsing and generation of list views with sorting, filtering,
   and action buttons according to the Aurora UI specifications.
   """
 
-  import AuroraUixWeb.Templates.Core, only: [get_field: 3]
-  alias AuroraUixWeb.Template
+  import Aurora.Uix.Web.Templates.Core, only: [get_field: 3]
+  alias Aurora.Uix.Web.Template
 
   @doc """
   Parses the index layout configuration and generates the corresponding HEEX markup
@@ -42,7 +42,7 @@ defmodule AuroraUixWeb.Templates.Core.Markups.IndexLayout do
       parsed_opts,
       ~S"""
         <.live_component
-          module={AuroraUixWeb.Templates.Core.Components.Live.AuroraIndexList}
+          module={Aurora.Uix.Web.Templates.Core.Components.Live.AuroraIndexList}
           id="[[source]]"
           title="Listing [[title]]"
           module_name="[[title]]"

--- a/lib/aurora_uix_web/templates/core/markups/show_layout.ex
+++ b/lib/aurora_uix_web/templates/core/markups/show_layout.ex
@@ -1,13 +1,13 @@
-defmodule AuroraUixWeb.Templates.Core.Markups.ShowLayout do
+defmodule Aurora.Uix.Web.Templates.Core.Markups.ShowLayout do
   @moduledoc """
   Provides functionality for generating show view layout markup in HEEX templates.
   This module handles the parsing and generation of detail views with edit capabilities
   according to the Aurora UI specifications.
   """
 
-  import AuroraUixWeb.Templates.Core, only: [parse_layout: 5]
+  import Aurora.Uix.Web.Templates.Core, only: [parse_layout: 5]
 
-  alias AuroraUixWeb.Template
+  alias Aurora.Uix.Web.Template
 
   @doc """
   Parses the show layout configuration and generates the corresponding HEEX markup

--- a/lib/aurora_uix_web/uix.ex
+++ b/lib/aurora_uix_web/uix.ex
@@ -1,4 +1,4 @@
-defmodule AuroraUixWeb.Uix do
+defmodule Aurora.Uix.Web.Uix do
   @moduledoc """
   Provides a low-code, opinionated framework for building dynamic UIs in Phoenix applications.
 
@@ -22,11 +22,11 @@ defmodule AuroraUixWeb.Uix do
 
   ## Getting Started
 
-  To use `AuroraUixWeb.Uix`, simply `use` it in your module:
+  To use `Aurora.Uix.Web.Uix`, simply `use` it in your module:
 
   ```elixir
   defmodule MyAppWeb.ProductView do
-    use AuroraUixWeb.Uix
+    use Aurora.Uix.Web.Uix
 
     # Define schema configuration
     auix_resource_config :product,
@@ -54,7 +54,7 @@ defmodule AuroraUixWeb.Uix do
 
   ```elixir
   defmodule MyAppWeb.UserView do
-    use AuroraUixWeb.Uix
+    use Aurora.Uix.Web.Uix
 
     # Configure schema metadata
     auix_resource_config :user,
@@ -81,8 +81,8 @@ defmodule AuroraUixWeb.Uix do
 
   While it provides flexibility for customization, it works best when embracing its conventions.
   """
-  alias AuroraUixWeb.Uix.CreateUI
-  alias AuroraUixWeb.Uix.DataConfigUI
+  alias Aurora.Uix.Web.Uix.CreateUI
+  alias Aurora.Uix.Web.Uix.DataConfigUI
 
   require Logger
 

--- a/lib/aurora_uix_web/uix/create_ui.ex
+++ b/lib/aurora_uix_web/uix/create_ui.ex
@@ -1,4 +1,4 @@
-defmodule AuroraUixWeb.Uix.CreateUI do
+defmodule Aurora.Uix.Web.Uix.CreateUI do
   @moduledoc """
   Provides a comprehensive framework for dynamically generating UI layouts and views in Phoenix/Elixir applications.
 
@@ -15,7 +15,7 @@ defmodule AuroraUixWeb.Uix.CreateUI do
   - Support custom layout definitions
 
   ## Compilation Workflow
-  1. Module uses `use AuroraUixWeb.Uix.CreateUI`
+  1. Module uses `use Aurora.Uix.Web.Uix.CreateUI`
   2. Configurations are collected via module attributes
   3. `__before_compile__/1` macro triggers UI generation
   4. Modules are dynamically created based on configurations
@@ -23,7 +23,7 @@ defmodule AuroraUixWeb.Uix.CreateUI do
   ## Examples
   ```elixir
     defmodule MyApp.ProductViews do
-      use AuroraUixWeb.Uix.CreateUI
+      use Aurora.Uix.Web.Uix.CreateUI
       auix_create_ui for: :product do
         index_columns :product, [:name, :price]
         edit_layout :product do
@@ -39,19 +39,19 @@ defmodule AuroraUixWeb.Uix.CreateUI do
   - Supports complex, nested layouts
   """
 
-  import AuroraUixWeb.Uix.Helper
+  import Aurora.Uix.Web.Uix.Helper
 
-  alias AuroraUix.Parser
-  alias AuroraUixWeb.Template
-  alias AuroraUixWeb.Uix.CreateUI
-  alias AuroraUixWeb.Uix.LayoutConfigUI
+  alias Aurora.Uix.Parser
+  alias Aurora.Uix.Web.Template
+  alias Aurora.Uix.Web.Uix.CreateUI
+  alias Aurora.Uix.Web.Uix.LayoutConfigUI
 
   defmacro __using__(_opts) do
     quote do
-      import AuroraUixWeb.Uix.CreateUI
-      use AuroraUixWeb.Uix.LayoutConfigUI
+      import Aurora.Uix.Web.Uix.CreateUI
+      use Aurora.Uix.Web.Uix.LayoutConfigUI
 
-      @before_compile AuroraUixWeb.Uix.CreateUI
+      @before_compile Aurora.Uix.Web.Uix.CreateUI
     end
   end
 
@@ -223,7 +223,7 @@ defmodule AuroraUixWeb.Uix.CreateUI do
   # Returns a map with the following format:
   #  %{
   #    resource_config_name: resource_config_name, Name of the resource, being configured.
-  #    resource_config: resource_config, # Instance of AuroraUix.ResourceConfigUI struct.
+  #    resource_config: resource_config, # Instance of Aurora.Uix.ResourceConfigUI struct.
   #    layouts: layouts, # List of layouts map TODO: should be provided by the template
   #    parsed_opts: parsed_opts, # Parsed options for the layout.
   #    defaulted_paths: defaulted_paths, # Paths making up the UI.

--- a/lib/aurora_uix_web/uix/data_config_ui.ex
+++ b/lib/aurora_uix_web/uix/data_config_ui.ex
@@ -1,4 +1,4 @@
-defmodule AuroraUixWeb.Uix.DataConfigUI do
+defmodule Aurora.Uix.Web.Uix.DataConfigUI do
   @moduledoc """
   Provides a comprehensive, declarative UI configuration system for structured data in Phoenix LiveView.
 
@@ -80,19 +80,19 @@ defmodule AuroraUixWeb.Uix.DataConfigUI do
   - Extensible through custom parsing and rendering strategies
   """
 
-  import AuroraUixWeb.Uix.Helper
+  import Aurora.Uix.Web.Uix.Helper
 
-  alias AuroraUix.Field
-  alias AuroraUix.ResourceConfigUI
-  alias AuroraUixWeb.Uix.DataConfigUI
+  alias Aurora.Uix.Field
+  alias Aurora.Uix.ResourceConfigUI
+  alias Aurora.Uix.Web.Uix.DataConfigUI
 
   defmacro __using__(_opts) do
     quote do
-      import AuroraUixWeb.Uix.DataConfigUI
+      import Aurora.Uix.Web.Uix.DataConfigUI
 
       Module.register_attribute(__MODULE__, :_auix_process_resource_config, accumulate: true)
 
-      @before_compile AuroraUixWeb.Uix.DataConfigUI
+      @before_compile Aurora.Uix.Web.Uix.DataConfigUI
     end
   end
 

--- a/lib/aurora_uix_web/uix/helper.ex
+++ b/lib/aurora_uix_web/uix/helper.ex
@@ -1,6 +1,6 @@
-defmodule AuroraUixWeb.Uix.Helper do
+defmodule Aurora.Uix.Web.Uix.Helper do
   @moduledoc """
-  Helper module for AuroraUix UI DSL that provides utilities for processing HEEX markup and managing component state.
+  Helper module for Aurora.Uix UI DSL that provides utilities for processing HEEX markup and managing component state.
 
   Core functionalities:
   - DSL block processing and normalization

--- a/lib/aurora_uix_web/uix/layout_config_ui.ex
+++ b/lib/aurora_uix_web/uix/layout_config_ui.ex
@@ -1,4 +1,4 @@
-defmodule AuroraUixWeb.Uix.LayoutConfigUI do
+defmodule Aurora.Uix.Web.Uix.LayoutConfigUI do
   @moduledoc ~S"""
   Comprehensive layout configuration system for dynamic UI generation.
 
@@ -206,12 +206,12 @@ defmodule AuroraUixWeb.Uix.LayoutConfigUI do
 
   """
 
-  import AuroraUixWeb.Uix.Helper
+  import Aurora.Uix.Web.Uix.Helper
 
   @doc false
   defmacro __using__(_opts) do
     quote do
-      import AuroraUixWeb.Uix.LayoutConfigUI
+      import Aurora.Uix.Web.Uix.LayoutConfigUI
     end
   end
 
@@ -420,7 +420,7 @@ defmodule AuroraUixWeb.Uix.LayoutConfigUI do
 
   ## Example
 
-    iex> AuroraUixWeb.Uix.LayoutConfigUI.build_default_layout_paths([], "product", %{fields: [%{field: :name}, %{field: :price}]}, [], :index)
+    iex> Aurora.Uix.Web.Uix.LayoutConfigUI.build_default_layout_paths([], "product", %{fields: [%{field: :name}, %{field: :price}]}, [], :index)
     [
       %{tag: :index, state: :start, opts: [], config: {:fields, [:name, :price]}},
       %{tag: :index, state: :end}

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule AuroraUix.MixProject do
+defmodule Aurora.Uix.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/wadvanced/aurora_uix"

--- a/test/doctests/uix/doc_test.exs
+++ b/test/doctests/uix/doc_test.exs
@@ -1,7 +1,7 @@
 defmodule AuroraUixTest.Uix.DocTest do
   use ExUnit.Case, async: true
 
-  doctest AuroraUix.Field
-  doctest AuroraUix.Parser
-  doctest AuroraUix.ResourceConfigUI
+  doctest Aurora.Uix.Field
+  doctest Aurora.Uix.Parser
+  doctest Aurora.Uix.ResourceConfigUI
 end

--- a/test/doctests/uix/parsers_doc_test.exs
+++ b/test/doctests/uix/parsers_doc_test.exs
@@ -1,5 +1,5 @@
 defmodule AuroraUixTest.Uix.ParsersDocTest do
   use ExUnit.Case, async: true
 
-  doctest AuroraUix.Parsers.Common
+  doctest Aurora.Uix.Parsers.Common
 end

--- a/test/support/app_web/components/layouts/root.html.heex
+++ b/test/support/app_web/components/layouts/root.html.heex
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="csrf-token" content={get_csrf_token()} />
     <.live_title suffix=" · Phoenix Framework">
-      {assigns[:page_title] || "AuroraUix"}
+      {assigns[:page_title] || "Aurora.Uix"}
     </.live_title>
     <link phx-track_static rel="stylesheet" href={~p"/assets/app.css"} />
     <script defer phx-track_static type="text/javascript" src={~p"/assets/app.js"}>

--- a/test/support/aurora_uix_test_web.exs
+++ b/test/support/aurora_uix_test_web.exs
@@ -62,7 +62,7 @@ defmodule AuroraUixTestWeb do
     quote do
       Module.register_attribute(__MODULE__, :auix_resource_config, persist: true)
 
-      use AuroraUixWeb.Uix
+      use Aurora.Uix.Web.Uix
     end
   end
 
@@ -97,8 +97,8 @@ defmodule AuroraUixTestWeb do
   @spec html_helpers() :: Macro.t()
   defp html_helpers do
     quote do
-      use AuroraUixWeb.Gettext
-      use AuroraUixWeb.CoreComponents
+      use Aurora.Uix.Web.Gettext
+      use Aurora.Uix.Web.CoreComponents
 
       # HTML escaping functionality
       import Phoenix.HTML

--- a/test/support/ui_case.exs
+++ b/test/support/ui_case.exs
@@ -5,7 +5,7 @@ defmodule AuroraUixTest.UICase do
   Support for testing schema metadata behaviour.
   """
 
-  alias AuroraUix.Field
+  alias Aurora.Uix.Field
 
   @spec validate_schema(map, atom, map) :: boolean
   def validate_schema(resource_configs, schema, fields_checks) do


### PR DESCRIPTION
- For keeping aligned with the Aurora platform, AuroraUix was renamed to Aurora.Uix
- AuroraUixWeb renamed to Aurora.Uix.Web