### PR TITLE
Rename layout helper

### DIFF
--- a/lib/aurora_uix/layout/blueprint.ex
+++ b/lib/aurora_uix/layout/blueprint.ex
@@ -206,7 +206,7 @@ defmodule Aurora.Uix.Layout.Blueprint do
 
   """
 
-  import Aurora.Uix.Layout.Helper
+  alias Aurora.Uix.Layout.Helpers, as: LayoutHelpers
 
   @doc false
   defmacro __using__(_opts) do
@@ -236,7 +236,7 @@ defmodule Aurora.Uix.Layout.Blueprint do
   """
   @spec edit_layout(atom, keyword, any) :: Macro.t()
   defmacro edit_layout(name, opts, do_block \\ nil) do
-    register_dsl_entry(:form, name, nil, opts, do_block)
+    LayoutHelpers.register_dsl_entry(:form, name, nil, opts, do_block)
   end
 
   @doc """
@@ -254,7 +254,7 @@ defmodule Aurora.Uix.Layout.Blueprint do
   """
   @spec show_layout(atom, keyword, any) :: Macro.t()
   defmacro show_layout(name, opts, do_block \\ nil) do
-    register_dsl_entry(:show, name, nil, opts, do_block)
+    LayoutHelpers.register_dsl_entry(:show, name, nil, opts, do_block)
   end
 
   @doc """
@@ -272,7 +272,7 @@ defmodule Aurora.Uix.Layout.Blueprint do
   """
   @spec index_columns(atom, keyword, any) :: Macro.t()
   defmacro index_columns(name, fields, do_block \\ nil) do
-    register_dsl_entry(:index, name, {:fields, fields}, [], do_block)
+    LayoutHelpers.register_dsl_entry(:index, name, {:fields, fields}, [], do_block)
   end
 
   @doc """
@@ -302,8 +302,8 @@ defmodule Aurora.Uix.Layout.Blueprint do
   """
   @spec inline(keyword, any) :: Macro.t()
   defmacro inline(fields, do_block \\ nil) do
-    {block, fields} = extract_block_options(fields, do_block)
-    register_dsl_entry(:inline, nil, {:fields, fields}, [], block)
+    {block, fields} = LayoutHelpers.extract_block_options(fields, do_block)
+    LayoutHelpers.register_dsl_entry(:inline, nil, {:fields, fields}, [], block)
   end
 
   @doc """
@@ -323,8 +323,8 @@ defmodule Aurora.Uix.Layout.Blueprint do
   """
   @spec stacked(keyword, any) :: Macro.t()
   defmacro stacked(fields, do_block \\ nil) do
-    {block, fields} = extract_block_options(fields, do_block)
-    register_dsl_entry(:stacked, nil, {:fields, fields}, [], block)
+    {block, fields} = LayoutHelpers.extract_block_options(fields, do_block)
+    LayoutHelpers.register_dsl_entry(:stacked, nil, {:fields, fields}, [], block)
   end
 
   @doc """
@@ -342,7 +342,7 @@ defmodule Aurora.Uix.Layout.Blueprint do
   """
   @spec group(atom, keyword, any) :: Macro.t()
   defmacro group(title, opts, do_block \\ nil) do
-    register_dsl_entry(
+    LayoutHelpers.register_dsl_entry(
       :group,
       nil,
       [title: title, group_id: "auix-group-#{unique_titled_id(title)}"],
@@ -368,7 +368,7 @@ defmodule Aurora.Uix.Layout.Blueprint do
   """
   @spec sections(keyword, any) :: Macro.t()
   defmacro sections(opts, do_block \\ nil) do
-    register_dsl_entry(
+    LayoutHelpers.register_dsl_entry(
       :sections,
       nil,
       [sections_id: "auix-#{unique_titled_id("sections")}"],
@@ -392,7 +392,7 @@ defmodule Aurora.Uix.Layout.Blueprint do
   """
   @spec section(binary, keyword, any) :: Macro.t()
   defmacro section(label, opts, do_block \\ nil) do
-    register_dsl_entry(
+    LayoutHelpers.register_dsl_entry(
       :section,
       nil,
       [label: label, tab_id: "auix-section-#{unique_titled_id(label)}"],
@@ -531,7 +531,7 @@ defmodule Aurora.Uix.Layout.Blueprint do
   """
   @spec parse_sections(map, atom) :: map
   def parse_sections(path, mode) when mode in [:form, :show] do
-    pid = start_counter()
+    pid = LayoutHelpers.start_counter()
 
     path
     |> Map.get(:inner_elements, [])
@@ -636,7 +636,7 @@ defmodule Aurora.Uix.Layout.Blueprint do
          _tab_active?,
          result
        ) do
-    next_sections_index = next_count(counter_pid)
+    next_sections_index = LayoutHelpers.next_count(counter_pid)
 
     new_inner_elements =
       normalize_sections_and_tabs(

--- a/lib/aurora_uix/layout/create_ui.ex
+++ b/lib/aurora_uix/layout/create_ui.ex
@@ -40,10 +40,9 @@ defmodule Aurora.Uix.Layout.CreateUI do
   - Supports complex, nested layouts
   """
 
-  import Aurora.Uix.Layout.Helpers
-
   alias Aurora.Uix.Layout.Blueprint
   alias Aurora.Uix.Layout.CreateUI
+  alias Aurora.Uix.Layout.Helpers, as: LayoutHelpers
   alias Aurora.Uix.Parser
   alias Aurora.Uix.Template
 
@@ -111,9 +110,9 @@ defmodule Aurora.Uix.Layout.CreateUI do
   """
   @spec auix_create_ui(keyword(), Macro.t() | nil) :: Macro.t()
   defmacro auix_create_ui(opts \\ [], do_block \\ nil) do
-    {block, opts} = extract_block_options(opts, do_block)
+    {block, opts} = LayoutHelpers.extract_block_options(opts, do_block)
 
-    create_ui = register_dsl_entry(:ui, :ui, [], opts, block)
+    create_ui = LayoutHelpers.register_dsl_entry(:ui, :ui, [], opts, block)
 
     quote do
       use CreateUI

--- a/lib/aurora_uix/layout/create_ui.ex
+++ b/lib/aurora_uix/layout/create_ui.ex
@@ -40,7 +40,7 @@ defmodule Aurora.Uix.Layout.CreateUI do
   - Supports complex, nested layouts
   """
 
-  import Aurora.Uix.Layout.Helper
+  import Aurora.Uix.Layout.Helpers
 
   alias Aurora.Uix.Layout.Blueprint
   alias Aurora.Uix.Layout.CreateUI

--- a/lib/aurora_uix/layout/helper.ex
+++ b/lib/aurora_uix/layout/helper.ex
@@ -1,4 +1,4 @@
-defmodule Aurora.Uix.Layout.Helper do
+defmodule Aurora.Uix.Layout.Helpers do
   @moduledoc """
   Helper module for Aurora.Uix UI DSL that provides utilities for processing HEEX markup and managing component state.
 

--- a/lib/aurora_uix/layout/resource_metadata.ex
+++ b/lib/aurora_uix/layout/resource_metadata.ex
@@ -80,9 +80,8 @@ defmodule Aurora.Uix.Layout.ResourceMetadata do
   - Extensible through custom parsing and rendering strategies
   """
 
-  import Aurora.Uix.Layout.Helpers
-
   alias Aurora.Uix.Field
+  alias Aurora.Uix.Layout.Helpers, as: LayoutHelpers
   alias Aurora.Uix.Layout.ResourceMetadata
   alias Aurora.Uix.Resource
 
@@ -180,7 +179,7 @@ defmodule Aurora.Uix.Layout.ResourceMetadata do
   """
   @spec auix_resource_metadata(atom, keyword(), Macro.t() | nil) :: Macro.t()
   defmacro auix_resource_metadata(name, opts \\ [], do_block \\ nil) do
-    {block, opts} = extract_block_options(opts, do_block)
+    {block, opts} = LayoutHelpers.extract_block_options(opts, do_block)
 
     resource_config =
       quote do
@@ -188,7 +187,7 @@ defmodule Aurora.Uix.Layout.ResourceMetadata do
           tag: :resource,
           name: unquote(name),
           opts: unquote(opts),
-          inner_elements: unquote(prepare_block(block))
+          inner_elements: unquote(LayoutHelpers.prepare_block(block))
         }
       end
 
@@ -236,7 +235,7 @@ defmodule Aurora.Uix.Layout.ResourceMetadata do
   """
   @spec field(atom() | tuple(), keyword()) :: Macro.t()
   defmacro field(field, opts \\ []) do
-    register_dsl_entry(:field, field, [], opts, nil)
+    LayoutHelpers.register_dsl_entry(:field, field, [], opts, nil)
   end
 
   @doc """
@@ -277,7 +276,7 @@ defmodule Aurora.Uix.Layout.ResourceMetadata do
   # 4. Reordering fields by configuration order
   @spec configure_fields([map()]) :: list()
   defp configure_fields(resources) do
-    start_counter(:auix_fields)
+    LayoutHelpers.start_counter(:auix_fields)
     Enum.map(resources, &configure_resource_fields/1)
   end
 
@@ -373,7 +372,7 @@ defmodule Aurora.Uix.Layout.ResourceMetadata do
           |> Field.change(field.opts),
           fn field_struct -> field_struct.field == field.name end
         )
-        |> set_field_id()
+        |> LayoutHelpers.set_field_id()
       end)
       |> Enum.reverse()
 
@@ -454,7 +453,7 @@ defmodule Aurora.Uix.Layout.ResourceMetadata do
       data: field_data(association)
     }
 
-    attrs |> Field.new() |> set_field_id()
+    attrs |> Field.new() |> LayoutHelpers.set_field_id()
   end
 
   # Formats a display label from a field name
@@ -596,7 +595,7 @@ defmodule Aurora.Uix.Layout.ResourceMetadata do
   # Adds each association as a field with proper metadata
   @spec add_associations(list()) :: list
   defp add_associations(resources) do
-    start_counter(:auix_fields)
+    LayoutHelpers.start_counter(:auix_fields)
 
     Enum.map(resources, fn resource ->
       resource
@@ -638,7 +637,7 @@ defmodule Aurora.Uix.Layout.ResourceMetadata do
         resource: resource_name
       )
     )
-    |> set_field_id()
+    |> LayoutHelpers.set_field_id()
     |> then(&[&1 | fields])
   end
 

--- a/lib/aurora_uix/layout/resource_metadata.ex
+++ b/lib/aurora_uix/layout/resource_metadata.ex
@@ -80,7 +80,7 @@ defmodule Aurora.Uix.Layout.ResourceMetadata do
   - Extensible through custom parsing and rendering strategies
   """
 
-  import Aurora.Uix.Layout.Helper
+  import Aurora.Uix.Layout.Helpers
 
   alias Aurora.Uix.Field
   alias Aurora.Uix.Layout.ResourceMetadata

--- a/lib/aurora_uix/resource.ex
+++ b/lib/aurora_uix/resource.ex
@@ -13,7 +13,7 @@ defmodule Aurora.Uix.Resource do
   - Integrates with other Aurora.Uix parsing components
   """
 
-  import Aurora.Uix.Layout.Helper, only: [set_field_id: 1]
+  import Aurora.Uix.Layout.Helpers, only: [set_field_id: 1]
 
   alias Aurora.Uix.Field
 

--- a/lib/aurora_uix/resource.ex
+++ b/lib/aurora_uix/resource.ex
@@ -13,9 +13,8 @@ defmodule Aurora.Uix.Resource do
   - Integrates with other Aurora.Uix parsing components
   """
 
-  import Aurora.Uix.Layout.Helpers, only: [set_field_id: 1]
-
   alias Aurora.Uix.Field
+  alias Aurora.Uix.Layout.Helpers, as: LayoutHelpers
 
   defstruct [:name, :schema, :context, fields: [], fields_order: [], inner_elements: []]
 
@@ -132,13 +131,16 @@ defmodule Aurora.Uix.Resource do
       properties
       |> Map.put(:field, field)
       |> Field.new()
-      |> set_field_id()
+      |> LayoutHelpers.set_field_id()
 
     [new_field | acc]
   end
 
   defp create_field(%Field{} = field, acc), do: [field | acc]
-  defp create_field(%{field: _field_id} = attrs, _acc), do: attrs |> Field.new() |> set_field_id()
+
+  defp create_field(%{field: _field_id} = attrs, _acc),
+    do: attrs |> Field.new() |> LayoutHelpers.set_field_id()
+
   defp create_field(_field, acc), do: acc
 
   # Filters attributes list by key

--- a/lib/aurora_uix/templates/basic/generators/form_generator.ex
+++ b/lib/aurora_uix/templates/basic/generators/form_generator.ex
@@ -56,14 +56,14 @@ defmodule Aurora.Uix.Web.Templates.Basic.Generators.FormGenerator do
 
         import unquote(core_helpers)
 
-        alias Aurora.Uix.Layout.Helper, as: LayoutHelper
+        alias Aurora.Uix.Layout.Helpers, as: LayoutHelpers
         alias Aurora.Uix.Stack
         alias Aurora.Uix.Web.Templates.Basic.Renderer
         alias unquote(modules.context)
 
         @impl true
         def update(%{:auix_entity => entity} = assigns, socket) do
-          LayoutHelper.start_counter(:auix_fields)
+          LayoutHelpers.start_counter(:auix_fields)
 
           form =
             unquote(modules.context)

--- a/lib/aurora_uix/templates/basic/generators/index_generator.ex
+++ b/lib/aurora_uix/templates/basic/generators/index_generator.ex
@@ -44,7 +44,7 @@ defmodule Aurora.Uix.Web.Templates.Basic.Generators.IndexGenerator do
 
         import unquote(core_helpers)
 
-        alias Aurora.Uix.Layout.Helper, as: LayoutHelper
+        alias Aurora.Uix.Layout.Helpers, as: LayoutHelpers
         alias Aurora.Uix.Web.Templates.Basic.Renderer
         alias unquote(modules.context)
         alias unquote(modules.module)
@@ -62,7 +62,7 @@ defmodule Aurora.Uix.Web.Templates.Basic.Generators.IndexGenerator do
 
         @impl true
         def handle_params(params, url, socket) do
-          LayoutHelper.start_counter(:auix_fields)
+          LayoutHelpers.start_counter(:auix_fields)
 
           {:noreply,
            socket

--- a/lib/aurora_uix/templates/basic/generators/show_generator.ex
+++ b/lib/aurora_uix/templates/basic/generators/show_generator.ex
@@ -41,7 +41,7 @@ defmodule Aurora.Uix.Web.Templates.Basic.Generators.ShowGenerator do
 
         import unquote(core_helpers)
 
-        alias Aurora.Uix.Layout.Helper, as: LayoutHelper
+        alias Aurora.Uix.Layout.Helpers, as: LayoutHelpers
         alias Aurora.Uix.Web.Templates.Basic.Renderer
         alias unquote(modules.context)
         alias unquote(modules.module)
@@ -55,7 +55,7 @@ defmodule Aurora.Uix.Web.Templates.Basic.Generators.ShowGenerator do
 
         @impl true
         def handle_params(%{"id" => id} = params, url, socket) do
-          LayoutHelper.start_counter(:auix_fields)
+          LayoutHelpers.start_counter(:auix_fields)
 
           {:noreply,
            socket

--- a/lib/aurora_uix/templates/basic/helpers.ex
+++ b/lib/aurora_uix/templates/basic/helpers.ex
@@ -9,7 +9,7 @@ defmodule Aurora.Uix.Web.Templates.Basic.Helpers do
   use Phoenix.LiveComponent
 
   import Aurora.Uix.Template, only: [safe_existing_atom: 1]
-  import Aurora.Uix.Layout.Helper, only: [set_field_id: 1]
+  import Aurora.Uix.Layout.Helpers, only: [set_field_id: 1]
 
   alias Aurora.Uix.Field
   alias Aurora.Uix.Stack

--- a/lib/aurora_uix/templates/basic/helpers.ex
+++ b/lib/aurora_uix/templates/basic/helpers.ex
@@ -9,9 +9,9 @@ defmodule Aurora.Uix.Web.Templates.Basic.Helpers do
   use Phoenix.LiveComponent
 
   import Aurora.Uix.Template, only: [safe_existing_atom: 1]
-  import Aurora.Uix.Layout.Helpers, only: [set_field_id: 1]
 
   alias Aurora.Uix.Field
+  alias Aurora.Uix.Layout.Helpers, as: LayoutHelpers
   alias Aurora.Uix.Stack
   alias Phoenix.LiveView.JS
 
@@ -301,7 +301,7 @@ defmodule Aurora.Uix.Web.Templates.Basic.Helpers do
     |> Map.get(:fields, %{})
     |> Map.get(field_name, Field.new(%{field: field_name, resource: resource_name}))
     |> Field.change(Map.get(field, :config, []))
-    |> set_field_id()
+    |> LayoutHelpers.set_field_id()
   end
 
   @doc """


### PR DESCRIPTION
Aurora.Uix.Layout.Helper renamed to Aurora.Uix.Layout.Helpers.

Changed all import of Aurora.Uix.Layout.Helpers to alias