### PR TITLE
Remove unneeded imports

### DIFF
--- a/lib/aurora_uix/helpers/core_components_importer.ex
+++ b/lib/aurora_uix/helpers/core_components_importer.ex
@@ -38,9 +38,13 @@ defmodule Aurora.Uix.Web.CoreComponentsImporter do
     core_components_module =
       opts[:core_components_module] || template.default_core_components_module()
 
+    template_component_modules =
+      Enum.map(template.template_component_modules(), &quote(do: import(unquote(&1))))
+
     quote do
       import Phoenix.Component
       import unquote(core_components_module)
+      unquote(template_component_modules)
     end
   end
 end

--- a/lib/aurora_uix/template.ex
+++ b/lib/aurora_uix/template.ex
@@ -102,6 +102,8 @@ defmodule Aurora.Uix.Template do
   """
   @callback default_core_components_module() :: module()
 
+  @callback template_component_modules() :: list(module())
+
   @doc """
   Returns CSS class mappings for different template components.
 

--- a/lib/aurora_uix/templates/basic.ex
+++ b/lib/aurora_uix/templates/basic.ex
@@ -28,6 +28,7 @@ defmodule Aurora.Uix.Web.Templates.Basic do
   @behaviour Aurora.Uix.Template
 
   alias Aurora.Uix.Web.Templates.Basic.ModulesGenerator
+  alias Aurora.Uix.Web.Templates.Basic.RoutingComponents
 
   @doc """
   Generates logic modules based on the provided configuration.
@@ -73,6 +74,11 @@ defmodule Aurora.Uix.Web.Templates.Basic do
       index_renderer: index_renderer(),
       show_renderer: show_renderer()
     }
+  end
+
+  @spec template_component_modules() :: list(module())
+  def template_component_modules do
+    [RoutingComponents]
   end
 
   ## PRIVATE

--- a/lib/aurora_uix/templates/basic/components/routing_components.ex
+++ b/lib/aurora_uix/templates/basic/components/routing_components.ex
@@ -9,9 +9,9 @@ defmodule Aurora.Uix.Web.Templates.Basic.RoutingComponents do
   - Accepts custom HTML attributes and content slots for flexible usage.
   """
 
-  use Aurora.Uix.Web.CoreComponentsImporter
   use Phoenix.Component
 
+  alias Aurora.Uix.Web.Templates.Basic.CoreComponents
   alias Phoenix.LiveView.Rendered
 
   @doc """
@@ -109,7 +109,7 @@ defmodule Aurora.Uix.Web.Templates.Basic.RoutingComponents do
         class="text-sm font-semibold leading-6 text-zinc-900 hover:text-zinc-700"
         {@rest}
       >
-        <.icon name="hero-arrow-left-solid" class="h-3 w-3" />
+        <CoreComponents.icon name="hero-arrow-left-solid" class="h-3 w-3" />
         {render_slot(@inner_block)}
       </a>
     </div>

--- a/lib/aurora_uix/templates/basic/renderers/index_renderer.ex
+++ b/lib/aurora_uix/templates/basic/renderers/index_renderer.ex
@@ -14,7 +14,6 @@ defmodule Aurora.Uix.Web.Templates.Basic.Renderers.IndexRenderer do
   """
 
   use Aurora.Uix.Web.CoreComponentsImporter
-  import Aurora.Uix.Web.Templates.Basic.RoutingComponents
 
   alias Aurora.Uix.Web.Templates.Basic.Helpers, as: BasicHelpers
   alias Phoenix.LiveView.JS

--- a/lib/aurora_uix/templates/basic/renderers/show_renderer.ex
+++ b/lib/aurora_uix/templates/basic/renderers/show_renderer.ex
@@ -13,7 +13,6 @@ defmodule Aurora.Uix.Web.Templates.Basic.Renderers.ShowRenderer do
   """
 
   use Aurora.Uix.Web.CoreComponentsImporter
-  import Aurora.Uix.Web.Templates.Basic.RoutingComponents
 
   alias Aurora.Uix.Web.Templates.Basic.Renderer
   alias Phoenix.LiveView.JS


### PR DESCRIPTION
- Routing component loaded as part of core_components_importer mechanism.
- Remove the import of RoutingComponents.