### PR TITLE
Solve auix_entity into auix assigns key

### DIFF
--- a/lib/aurora_uix/templates/basic/components/core_components.ex
+++ b/lib/aurora_uix/templates/basic/components/core_components.ex
@@ -47,7 +47,7 @@ defmodule Aurora.Uix.Web.Templates.Basic.CoreComponents do
   attr(:id, :string, required: true)
   attr(:show, :boolean, default: false)
   attr(:on_cancel, JS, default: %JS{})
-  attr(:auix_css_classes, :map, default: %{})
+  attr(:auix, :map, default: %{})
   slot(:inner_block, required: true)
 
   @spec modal(map) :: Rendered.t()
@@ -70,7 +70,7 @@ defmodule Aurora.Uix.Web.Templates.Basic.CoreComponents do
         tabindex="0"
       >
         <div class="flex min-h-full items-center justify-center">
-          <div class={get_in(@auix_css_classes, [:core_components, :modal_inner_container]) || "w-full max-w-3xl p-4 sm:p-6 lg:py-8"}>
+          <div class={get_in(@auix, [:css_classes, :core_components, :modal_inner_container]) || "w-full max-w-3xl p-4 sm:p-6 lg:py-8"}>
             <.focus_wrap
               id={"#{@id}-container"}
               phx-window-keydown={JS.exec("data-cancel", to: "##{@id}")}
@@ -494,7 +494,7 @@ defmodule Aurora.Uix.Web.Templates.Basic.CoreComponents do
     doc: "the function for mapping each row before calling the :col and :action slots"
   )
 
-  attr(:auix_css_classes, :map, default: %{})
+  attr(:auix, :map, default: %{})
 
   slot :col, required: true do
     attr(:label, :string)
@@ -510,7 +510,7 @@ defmodule Aurora.Uix.Web.Templates.Basic.CoreComponents do
       end
 
     ~H"""
-    <div class={get_in(@auix_css_classes, [:core_components, :table_container]) || "overflow-y-auto px-4 sm:overflow-visible sm:px-0"}>
+    <div class={get_in(@auix, [:css_classes, :core_components, :table_container]) || "overflow-y-auto px-4 sm:overflow-visible sm:px-0"}>
       <table class="w-[40rem] mt-11 sm:w-full">
         <thead class="text-sm text-left leading-6 text-zinc-500">
           <tr>

--- a/lib/aurora_uix/templates/basic/generators/index_generator.ex
+++ b/lib/aurora_uix/templates/basic/generators/index_generator.ex
@@ -159,13 +159,13 @@ defmodule Aurora.Uix.Web.Templates.Basic.Generators.IndexGenerator do
 
         ## PRIVATE
 
-        @spec apply_action(Phoenix.LiveView.Socket.t(), atom, map) :: Phoenix.LiveView.t()
+        @spec apply_action(Phoenix.LiveView.Socket.t(), atom(), map()) :: Phoenix.LiveView.t()
         defp apply_action(socket, :edit, %{"id" => id} = params) do
           socket
           |> assign_auix_option(:edit_title)
           |> assign_auix_option(:edit_subtitle)
-          |> assign(
-            :auix_entity,
+          |> assign_auix(
+            :entity,
             apply(unquote(modules.context), unquote(get_function), [
               id,
               [preload: unquote(Macro.escape(parsed_opts.preload))]
@@ -190,7 +190,7 @@ defmodule Aurora.Uix.Web.Templates.Basic.Generators.IndexGenerator do
           socket
           |> assign_auix_option(:page_title)
           |> assign_auix_option(:page_subtitle)
-          |> assign(:auix_entity, nil)
+          |> assign_auix(:entity, nil)
         end
       end
     end

--- a/lib/aurora_uix/templates/basic/generators/show_generator.ex
+++ b/lib/aurora_uix/templates/basic/generators/show_generator.ex
@@ -59,8 +59,8 @@ defmodule Aurora.Uix.Web.Templates.Basic.Generators.ShowGenerator do
            socket
            |> assign_parsed_opts(unquote(Macro.escape(parsed_opts)))
            |> assign_auix_new(:_sections, %{})
-           |> assign(
-             :auix_entity,
+           |> assign_auix(
+             :entity,
              apply(unquote(modules.context), unquote(get_function), [
                id,
                [preload: unquote(Macro.escape(parsed_opts.preload))]

--- a/lib/aurora_uix/templates/basic/renderer.ex
+++ b/lib/aurora_uix/templates/basic/renderer.ex
@@ -51,7 +51,7 @@ defmodule Aurora.Uix.Web.Templates.Basic.Renderer do
     ~H"""
     <div id={@auix.layout_tree.config[:group_id]} class="p-3 border rounded-md bg-gray-100">
       <h3 class="font-semibold text-lg"><%= @auix.layout_tree.config[:title] %></h3>
-      <.render_inner_elements auix={@auix} auix_entity={@auix_entity} />
+      <.render_inner_elements auix={@auix} auix_entity={@auix.entity} />
     </div>
     """
   end
@@ -60,7 +60,7 @@ defmodule Aurora.Uix.Web.Templates.Basic.Renderer do
   def render(%{auix: %{layout_tree: %{tag: :inline}}} = assigns) do
     ~H"""
     <div class="flex flex-col gap-2 sm:flex-row">
-      <.render_inner_elements auix={@auix} auix_entity={@auix_entity} />
+      <.render_inner_elements auix={@auix} auix_entity={@auix.entity} />
     </div>
     """
   end
@@ -68,7 +68,7 @@ defmodule Aurora.Uix.Web.Templates.Basic.Renderer do
   def render(%{auix: %{layout_tree: %{tag: :stacked}}} = assigns) do
     ~H"""
     <div class="flex flex-col gap-2">
-      <.render_inner_elements auix={@auix} auix_entity={@auix_entity} />
+      <.render_inner_elements auix={@auix} auix_entity={@auix.entity} />
     </div>
     """
   end
@@ -105,7 +105,7 @@ defmodule Aurora.Uix.Web.Templates.Basic.Renderer do
   @spec render_inner_elements(map()) :: Phoenix.LiveView.Rendered.t()
   def render_inner_elements(assigns) do
     ~H"""
-    <.render auix={Map.put(@auix, :layout_tree, inner_path)} auix_entity={@auix_entity} :for={inner_path <- @auix.layout_tree.inner_elements} />
+    <.render auix={Map.put(@auix, :layout_tree, inner_path)} auix_entity={@auix.entity} :for={inner_path <- @auix.layout_tree.inner_elements} />
     """
   end
 end

--- a/lib/aurora_uix/templates/basic/renderers/field_renderer.ex
+++ b/lib/aurora_uix/templates/basic/renderers/field_renderer.ex
@@ -23,7 +23,6 @@ defmodule Aurora.Uix.Web.Templates.Basic.Renderers.FieldRenderer do
   ## Parameters
   - assigns (map()) - LiveView assigns; must include:
     - auix (map()) - Aurora UIX context
-    - auix_entity (map()) - Entity being rendered
     - field (map()) - Field configuration and metadata
 
   ## Returns
@@ -100,14 +99,14 @@ defmodule Aurora.Uix.Web.Templates.Basic.Renderers.FieldRenderer do
     <%= if @field.hidden do %>
       <input type="hidden" id={"#{@field.html_id}-#{@auix.layout_type}"}
         {if @auix.layout_type == :form, do: %{name: @auix._form[@field.key].name, value: @auix._form[@field.key].value},
-         else: %{name: @field.key, value: @auix_entity[@field.key]}} />
+         else: %{name: @field.key, value: @auix.entity[@field.key]}} />
     <% else %>
       <div class="flex flex-col">
         <.input
           id={"#{@field.html_id}-#{@auix.layout_type}"}
           {if @auix.layout_type == :form,
             do: %{field: @auix._form[@field.key]},
-            else: %{name: @field.key, value: Map.get(@auix_entity || %{}, @field.key)}}
+            else: %{name: @field.key, value: Map.get(@auix.entity || %{}, @field.key)}}
           type={"#{@field.html_type}"}
           label={@field.label}
           options={@select_opts[:options]}

--- a/lib/aurora_uix/templates/basic/renderers/fields/many_to_one.ex
+++ b/lib/aurora_uix/templates/basic/renderers/fields/many_to_one.ex
@@ -100,7 +100,7 @@ defmodule Aurora.Uix.Web.Templates.Basic.Renderers.ManyToOne do
        do: assigns
 
   defp parse_many_to_one_value(
-         %{auix: %{layout_tree: %{name: names}, layout_type: :show}, auix_entity: entity} =
+         %{auix: %{layout_tree: %{name: names}, layout_type: :show, entity: entity}} =
            assigns
        )
        when is_tuple(names) do
@@ -108,7 +108,7 @@ defmodule Aurora.Uix.Web.Templates.Basic.Renderers.ManyToOne do
     |> Tuple.to_list()
     |> delete_last()
     |> Enum.reduce(entity, &Map.get(&2, &1, %{}))
-    |> then(&Map.put(assigns, :auix_entity, &1))
+    |> then(&put_in(assigns, [:auix, :entity], &1))
   end
 
   defp parse_many_to_one_value(
@@ -119,7 +119,7 @@ defmodule Aurora.Uix.Web.Templates.Basic.Renderers.ManyToOne do
     |> Tuple.to_list()
     |> List.first()
     |> then(&%{&1 => form[&1].value})
-    |> then(&Map.put(assigns, :auix_entity, &1))
+    |> then(&put_in(assigns, [:auix, :entity], &1))
     |> put_in([:auix, :layout_type], :show)
     |> parse_many_to_one_value()
   end

--- a/lib/aurora_uix/templates/basic/renderers/fields/one_to_many.ex
+++ b/lib/aurora_uix/templates/basic/renderers/fields/one_to_many.ex
@@ -72,8 +72,8 @@ defmodule Aurora.Uix.Web.Templates.Basic.Renderers.OneToMany do
     <div class="flex flex-col">
       <div class="flex-row gap-4">
         <.label for={"auix-one_to_many-#{@parsed_opts.module}__#{@field.key}-#{@auix.layout_type}"}>{"#{@related_parsed_opts.title} Elements"}
-            <.auix_link :if={!@related_parsed_opts.disable_index_new_link && @auix[:layout_type] == :form && @auix_entity.id != nil}
-                navigate={"#{@related_parsed_opts.index_new_link}?related_key=#{@related_key}&parent_id=#{Map.get(@auix_entity, @owner_key)}"}
+            <.auix_link :if={!@related_parsed_opts.disable_index_new_link && @auix[:layout_type] == :form && @auix.entity.id != nil}
+                navigate={"#{@related_parsed_opts.index_new_link}?related_key=#{@related_key}&parent_id=#{Map.get(@auix.entity, @owner_key)}"}
                 id={"auix-new-#{@parsed_opts.module}__#{@field.key}-#{@auix.layout_type}"}>
               <.icon name="hero-plus" />
             </.auix_link>
@@ -82,8 +82,8 @@ defmodule Aurora.Uix.Web.Templates.Basic.Renderers.OneToMany do
       <div id={"auix-one_to_many-#{@parsed_opts.module}__#{@field.key}-#{@auix.layout_type}"} class={@related_class}>
         <.table
           id={"#{@parsed_opts.module}__#{@field.key}-#{@auix.layout_type}"}
-          auix_css_classes={@auix.css_classes}
-          rows={Map.get(@auix_entity, @field.key)}
+          auix={%{css_classes: @auix.css_classes}}
+          rows={get_in(@auix, [:entity, Access.key!(@field.key)])}
           row_click_navigate={if @related_parsed_opts.disable_index_row_click, do: nil, else: build_row_click(@related_parsed_opts, @related_path)}
         >
           <:col :let={entity} :for={related_field <- @related_fields} label={"#{related_field.label}"}><.auix_link navigate={"/#{@related_parsed_opts.link_prefix}#{@related_parsed_opts.source}/#{entity.id}"}>{Map.get(entity, related_field.key)}</.auix_link></:col>
@@ -131,7 +131,7 @@ defmodule Aurora.Uix.Web.Templates.Basic.Renderers.OneToMany do
   # Returns path template with placeholders for dynamic values
   @spec build_related_path(binary(), map()) :: binary()
   defp build_related_path(source, data) do
-    "source=#{source}/\#{@auix_entity.id}&related_key=#{data.related_key}&parent_id=\#{@auix_entity.#{data.owner_key}}"
+    "source=#{source}/\#{@auix.entity.id}&related_key=#{data.related_key}&parent_id=\#{@auix.entity.#{data.owner_key}}"
   end
 
   # Gets field configurations for associations from the resource configurations

--- a/lib/aurora_uix/templates/basic/renderers/form_renderer.ex
+++ b/lib/aurora_uix/templates/basic/renderers/form_renderer.ex
@@ -45,7 +45,7 @@ defmodule Aurora.Uix.Web.Templates.Basic.Renderers.FormRenderer do
         phx-submit="save"
       >
         <div class="auix-form-container p-4 border rounded-lg shadow bg-white" data-layout={@auix.layout_tree.name}>
-          <Renderer.render_inner_elements auix={@auix} auix_entity={@auix_entity} />
+          <Renderer.render_inner_elements auix={@auix} auix_entity={@auix.entity} />
         </div>
 
         <:actions>

--- a/lib/aurora_uix/templates/basic/renderers/index_renderer.ex
+++ b/lib/aurora_uix/templates/basic/renderers/index_renderer.ex
@@ -24,7 +24,6 @@ defmodule Aurora.Uix.Web.Templates.Basic.Renderers.IndexRenderer do
   ## Parameters
   - assigns (map()) - LiveView assigns containing:
     - auix: Aurora UIX context with configurations and layout_tree info
-    - auix_entity: Entity being rendered
     - live_action: Current live action (:new, :edit)
     - page_title: Page title for modals
 
@@ -49,7 +48,7 @@ defmodule Aurora.Uix.Web.Templates.Basic.Renderers.IndexRenderer do
       |> then(&Map.put(assigns, :index_fields, &1))
 
     ~H"""
-    <div class={get_in(@auix.css_classes, [:index_renderer, :top_container]) || ""}>
+    <div class={get_in(@auix, [:css_classes, :index_renderer, :top_container]) || ""}>
       <.header>
         {@auix.layout_options.page_title}
         <:actions>
@@ -61,7 +60,7 @@ defmodule Aurora.Uix.Web.Templates.Basic.Renderers.IndexRenderer do
 
       <.table
         id={"auix-table-#{@auix.link_prefix}#{@auix.source}-index"}
-        auix_css_classes={@auix.css_classes}
+        auix={%{css_classes: @auix.css_classes}}
         rows={get_in(assigns, @auix.rows)}
         row_click_navigate={fn {_id, entity} -> "/#{@auix.link_prefix}#{@auix.source}/#{entity.id}" end}
       >
@@ -84,17 +83,15 @@ defmodule Aurora.Uix.Web.Templates.Basic.Renderers.IndexRenderer do
         </:action>
       </.table>
 
-      <.modal :if={@live_action in [:new, :edit]} auix_css_classes={@auix.css_classes} id={"auix-#{@auix.module}-modal"} show on_cancel={JS.push("auix_route_back")}>
+      <.modal :if={@live_action in [:new, :edit]} auix={%{css_classes: @auix.css_classes}} id={"auix-#{@auix.module}-modal"} show on_cancel={JS.push("auix_route_back")}>
         <div>
           <.live_component
             module={@auix._form_component}
-            id={@auix_entity.id || :new}
+            id={@auix.entity.id || :new}
             title={if @live_action == :edit, do: @auix.layout_options.edit_title, else: @auix.layout_options.new_title}
             subtitle={if @live_action == :edit, do: @auix.layout_options.edit_subtitle, else: @auix.layout_options.new_subtitle}
             action={@live_action}
-            auix_entity={@auix_entity}
-            auix_routing_stack={@auix._routing_stack}
-            auix_css_classes={@auix.css_classes}
+            auix={%{css_classes: @auix.css_classes, entity: @auix.entity, routing_stack: @auix.routing_stack}}
           />
         </div>
       </.modal>

--- a/lib/aurora_uix/templates/basic/renderers/sections_renderer.ex
+++ b/lib/aurora_uix/templates/basic/renderers/sections_renderer.ex
@@ -55,7 +55,7 @@ defmodule Aurora.Uix.Web.Templates.Basic.Renderers.SectionsRenderer do
         <% end %>
       </div>
       <div class="auix-sections-content p-4 border border-gray-300 rounded-tr-lg rounded-br-lg rounded-bl-lg">
-        <Renderer.render_inner_elements auix={@auix} auix_entity={@auix_entity} />
+        <Renderer.render_inner_elements auix={@auix} auix_entity={@auix.entity} />
       </div>
     </div>
     """
@@ -82,7 +82,7 @@ defmodule Aurora.Uix.Web.Templates.Basic.Renderers.SectionsRenderer do
       data-tab-sections-index={@auix.layout_tree.config[:sections_index]}
       data-tab-index={@auix.layout_tree.config[:tab_index]}
       data-tab-active={if @auix._sections[@auix.layout_tree.config[:sections_id]] == @auix.layout_tree.config[:tab_id] or (@auix._sections[@auix.layout_tree.config[:sections_id]] == nil and @auix.layout_tree.config[:active]), do: "active", else: "inactive"}>
-      <Renderer.render_inner_elements auix={@auix} auix_entity={@auix_entity} />
+      <Renderer.render_inner_elements auix={@auix} auix_entity={@auix.entity} />
     </div>
     """
   end

--- a/lib/aurora_uix/templates/basic/renderers/show_renderer.ex
+++ b/lib/aurora_uix/templates/basic/renderers/show_renderer.ex
@@ -23,7 +23,6 @@ defmodule Aurora.Uix.Web.Templates.Basic.Renderers.ShowRenderer do
   ## Parameters
   - assigns (map()) - LiveView assigns containing:
     - auix: Aurora UIX context with configurations and layout_tree info
-    - auix_entity: Entity being displayed
     - live_action: Current live action (:edit)
     - page_title: Title for edit modal
     - subtitle: Optional subtitle for the header
@@ -39,31 +38,29 @@ defmodule Aurora.Uix.Web.Templates.Basic.Renderers.ShowRenderer do
         {@auix.layout_options.page_title}
         <:subtitle :if={@auix.layout_options.page_subtitle != nil}>{@auix.layout_options.page_subtitle}</:subtitle>
         <:actions>
-          <.auix_link patch={"/#{@auix.link_prefix}#{@auix.source}/#{@auix_entity.id}/show/edit"} id={"auix-edit-#{@auix.module}"}>
+          <.auix_link patch={"/#{@auix.link_prefix}#{@auix.source}/#{@auix.entity.id}/show/edit"} id={"auix-edit-#{@auix.module}"}>
             <.button>Edit {@auix.name}</.button>
           </.auix_link>
         </:actions>
       </.header>
 
       <div class="auix-show-container p-4 border rounded-lg shadow bg-white" data-layout="#{name}">
-        <Renderer.render_inner_elements auix={@auix} auix_entity={@auix_entity} />
+        <Renderer.render_inner_elements auix={@auix} auix_entity={@auix.entity} />
       </div>
 
       <div id="auix-show-navigate-back">
         <.auix_back>Back to {@auix.title}</.auix_back>
       </div>
 
-      <.modal :if={@live_action == :edit} auix_css_classes={@auix.css_classes} id={"auix-#{@auix.module}-modal"} show on_cancel={JS.push("auix_route_back")}>
+      <.modal :if={@live_action == :edit} auix={%{css_classes: @auix.css_classes}} id={"auix-#{@auix.module}-modal"} show on_cancel={JS.push("auix_route_back")}>
         <div>
           <.live_component
             module={@auix._form_component}
-            id={@auix_entity.id || :new}
+            id={@auix.entity.id || :new}
             title={@auix.layout_options.edit_title}
             subtitle={@auix.layout_options.edit_subtitle}
             action={@live_action}
-            auix_entity={@auix_entity}
-            auix_routing_stack={@auix._routing_stack}
-            auix_css_classes={@auix.css_classes}
+            auix={%{css_classes: @auix.css_classes, entity: @auix.entity, routing_stack: @auix.routing_stack}}
           />
         </div>
       </.modal>

--- a/test/cases_live/create_ui_layout_test.exs
+++ b/test/cases_live/create_ui_layout_test.exs
@@ -18,10 +18,10 @@ defmodule Aurora.Uix.Test.Web.CreateUILayoutTest do
     def edit_title(%{auix: %{_form: _form}} = assigns),
       do: ~H"Modify {@auix.name}: #{inspect(@auix._form)} "
 
-    def edit_title(%{auix_entity: nil} = assigns), do: ~H"Modify {@auix.name}"
+    def edit_title(%{auix: %{entity: nil}} = assigns), do: ~H"Modify {@auix.name}"
 
-    def edit_title(%{auix_entity: _entity} = assigns),
-      do: ~H"Modify {@auix.name}: {@auix_entity.reference}"
+    def edit_title(%{auix: %{entity: _entity}} = assigns),
+      do: ~H"Modify {@auix.name}: {@auix.entity.reference}"
 
     @spec new_subtitle(map()) :: term()
     def new_subtitle(assigns),


### PR DESCRIPTION
- Set @auix.entity with the entity instance
- Rename @auix_entity into @auix.entity
- Remove unneeded function from the BasicHelpers
- Use of @auix.entity to pass entities among components
- Changed use of @auix._routing stack to @auix.routing_stack even among liveviews and components.
- Changed use of @auix_css_classes to @auix.css_classes even among liveviews and components.