### PR TITLE
Order by implemented

### DIFF
--- a/guides/core/resource_metadata.md
+++ b/guides/core/resource_metadata.md
@@ -48,7 +48,12 @@ Aurora UIX supports two types of associations: **many-to-one** (`belongs_to`) an
 
 ### Many-to-One
 
+By default, if a field represents a many-to-one association, it is automatically considered a select html type, and will 
+be rendered as such. You can bypass this behaviour by setting the `html_type` option to another type.
+
 The `option_label` option is used **only** for many-to-one associations rendered as select dropdowns. It controls what is shown as the label for each option in the dropdown. By default, the related key (usually an ID) is shown, but you can specify a field (atom), a function, or a function with arity 2 for more advanced labeling.
+
+The `order_by` option is used **only** for many-to-one associations rendered as select dropdowns when the `option_label` option is set to a field.
 
 **Usage:**
 
@@ -75,14 +80,25 @@ The `option_label` option is used **only** for many-to-one associations rendered
   ```
   The function receives the assigns and each instance of the associated entity, and should return a string label.
 
-**Example:**
+**Examples:**
 
 ```elixir
+# Renders a selector displaying the name contents as the option labels.
+# Options are ordered by name.
 auix_resource_metadata :product, schema: MyApp.Product do
   field :category_id, html_type: :select, option_label: :name
+end
+```
+```elixir
+# Renders a selector displaying the name contents as the option labels.
+# Options are ordered by the reference contents (not displayed).
+auix_resource_metadata :product, context: Inventory, schema: Product do
+  field :category_id, option_label: :name, order_by: [desc: :reference]
 end
 ```
 
 ### One-to-Many
 
-For **one-to-many associations** (`has_many`), the `option_label` option is not applicable.
+Fields representing a **one-to-many** (`has_many`) association are rendered as a list with actions
+for adding, editing, deleting and sorting.
+

--- a/lib/aurora_uix/field.ex
+++ b/lib/aurora_uix/field.ex
@@ -167,6 +167,7 @@ defmodule Aurora.Uix.Field do
   @doc """
   Implements `Access.fetch/2` for the field struct.
   """
+  @impl Access
   @spec fetch(__MODULE__.t(), atom()) :: any()
   def fetch(field, key) do
     Map.get(field, key)
@@ -175,6 +176,7 @@ defmodule Aurora.Uix.Field do
   @doc """
   Implements `Access.get_and_update/3` for the field struct.
   """
+  @impl Access
   @spec get_and_update(map(), atom(), (any() -> {any(), any()} | :pop)) :: {any(), map()}
   def get_and_update(data, key, function) do
     data
@@ -186,6 +188,7 @@ defmodule Aurora.Uix.Field do
   @doc """
   Implements `Access.pop/2` for the field struct.
   """
+  @impl Access
   @spec pop(map(), atom()) :: {any(), map()}
   def pop(data, key) do
     if Map.has_key?(data, key) do

--- a/lib/aurora_uix/layout/blueprint.ex
+++ b/lib/aurora_uix/layout/blueprint.ex
@@ -314,9 +314,27 @@ defmodule Aurora.Uix.Layout.Blueprint do
 
 
   ## Options
-  - `:page_title` (binary() | (map() -> Phoenix.LiveView.Rendered.t())): The page title for the index layout. Example: `page_title: "Products List"` or `page_title: &custom_page_title/1`.
-  - `:page_subtitle` (binary() | (map() -> Phoenix.LiveView.Rendered.t())): The page subtitle for the index layout. Example: `page_subtitle: "All available products"` or `page_subtitle: &custom_page_subtitle/1`.
+  - `:page_title` (binary() | (map() - Phoenix.LiveView.Rendered.t())): The page title for the index layout. Example: `page_title: "Products List"` or `page_title: &custom_page_title/1`.
+  - `:page_subtitle` (binary() | (map() - Phoenix.LiveView.Rendered.t())): The page subtitle for the index layout. Example: `page_subtitle: "All available products"` or `page_subtitle: &custom_page_subtitle/1`.
+  - `:order_by` (atom() | list() | keyword()) - Order used for displaying the index.
+    Takes precedence over any order_by set in `auix_resource_metadata`.
+    See `Aurora.Uix.Layout.ResourceMetadata.auix_resource_metadata/3` for details.
   - Field-level options can be provided as keyword lists for each field (e.g., `[name: [renderer: &custom_renderer/1]]`).
+
+  ## Field-level Options
+  Besides the metadata options, there are some field types that can accept specific options for changing the way they are rendered.
+
+  ### Fields representing **one-to-many** association.
+  - `:order_by` (atom() | list() | keyword()) - `Order by` used for displaying the related items.ç
+    Uses the same criteria as the `order_by` option described above.
+
+  ### Fields representing **many-to-one** association related field.
+  Those are the fields that referred the id that associates the many to one relation. For example: product_id.
+  They are, by default, represented as a select html type.
+  - `:option_label` (atom() | function()) - The label to be shown for each option. Can be:
+    - atom() - Renders the field contents.
+    - function/1 - Receives the entity as an argument, must return a `Phoenix.LiveView.Rendered.t()`
+    - function/2 - Receives assigns and the entity as arguments, expected to return `Phoenix.LiveView.Rendered.t()`
 
   ## Actions
   The following actions are available (see `Aurora.Uix.Web.Templates.Basic.Actions.Index` for details and usage):

--- a/lib/aurora_uix/parsers/common.ex
+++ b/lib/aurora_uix/parsers/common.ex
@@ -46,8 +46,7 @@ defmodule Aurora.Uix.Parsers.Common do
       :name,
       :source,
       :title,
-      :primary_key,
-      :default_order_by
+      :primary_key
     ]
   end
 
@@ -100,9 +99,6 @@ defmodule Aurora.Uix.Parsers.Common do
       key -> key
     end
   end
-
-  def default_value(parsed_opts, %{schema: _module}, :default_order_by),
-    do: parsed_opts[:primary_key]
 
   ## PRIVATE
 

--- a/lib/aurora_uix/resource.ex
+++ b/lib/aurora_uix/resource.ex
@@ -12,15 +12,17 @@ defmodule Aurora.Uix.Resource do
   - Allows runtime modification of schema metadata
   - Integrates with other Aurora.Uix parsing components
   """
+  @behaviour Access
 
   alias Aurora.Uix.Field
 
-  defstruct [:name, :schema, :context, fields: [], fields_order: [], inner_elements: []]
+  defstruct [:name, :schema, :context, opts: [], fields: [], fields_order: [], inner_elements: []]
 
   @type t() :: %__MODULE__{
           name: atom(),
           schema: module(),
           context: module() | nil,
+          opts: keyword(),
           fields: map() | list(),
           fields_order: list(),
           inner_elements: list()
@@ -79,6 +81,40 @@ defmodule Aurora.Uix.Resource do
   end
 
   def change(resource_config, %{} = attrs), do: struct(resource_config, attrs)
+
+  @doc """
+  Implements `Access.fetch/2` for the resource struct.
+  """
+  @impl Access
+  @spec fetch(__MODULE__.t(), atom()) :: any()
+  def fetch(resource, key) do
+    Map.get(resource, key)
+  end
+
+  @doc """
+  Implements `Access.get_and_update/3` for the resource struct.
+  """
+  @impl Access
+  @spec get_and_update(map(), atom(), (any() -> {any(), any()} | :pop)) :: {any(), map()}
+  def get_and_update(data, key, function) do
+    data
+    |> Map.get(key)
+    |> then(fn value -> function.(value) end)
+    |> then(&maybe_update_data(data, key, &1))
+  end
+
+  @doc """
+  Implements `Access.pop/2` for the resource struct.
+  """
+  @impl Access
+  @spec pop(map(), atom()) :: {any(), map()}
+  def pop(data, key) do
+    if Map.has_key?(data, key) do
+      {Map.get(data, key), Map.delete(data, key)}
+    else
+      {nil, data}
+    end
+  end
 
   ## PRIVATE
 
@@ -161,5 +197,14 @@ defmodule Aurora.Uix.Resource do
       {^key, _} -> true
       _ -> false
     end)
+  end
+
+  @spec maybe_update_data(map(), term(), tuple()) :: tuple()
+  defp maybe_update_data(data, key, {current_value, new_value}) do
+    {current_value, Map.put(data, key, new_value)}
+  end
+
+  defp maybe_update_data(data, key, :pop) do
+    {Map.get(data, key), Map.delete(data, key)}
   end
 end

--- a/lib/aurora_uix/templates/basic/handlers/index_impl.ex
+++ b/lib/aurora_uix/templates/basic/handlers/index_impl.ex
@@ -126,7 +126,20 @@ defmodule Aurora.Uix.Web.Templates.Basic.Handlers.IndexImpl do
   """
   @spec mount(map(), map(), Socket.t()) :: {:ok, Socket.t()}
   def mount(_params, _session, %{assigns: %{auix: auix}} = socket) do
-    {:ok, stream(socket, auix.list_key, auix.list_function.([]))}
+    layout_opts = Map.get(auix.layout_tree, :opts, [])
+
+    opts =
+      auix
+      |> get_in([:configurations, auix.resource_name, :resource_config])
+      |> Map.get(:opts, [])
+      |> Keyword.merge(layout_opts)
+
+    {:ok,
+     stream(
+       socket,
+       auix.list_key,
+       auix.list_function.(order_by: Keyword.get(opts, :order_by, []))
+     )}
   end
 
   @doc """

--- a/test/cases_live/association_many2one_selector_atom_test.exs
+++ b/test/cases_live/association_many2one_selector_atom_test.exs
@@ -7,6 +7,29 @@ defmodule Aurora.Uix.Test.Web.AssociationMany2OneSelectorAtomTest do
   alias Aurora.Uix.Test.Inventory.ProductLocation
   alias Aurora.Uix.Test.Inventory.ProductTransaction
 
+  @test_names [
+    "test-name-many2-20",
+    "test-name-many2-19",
+    "test-name-many2-18",
+    "test-name-many2-17",
+    "test-name-many2-16",
+    "test-name-many2-15",
+    "test-name-many2-14",
+    "test-name-many2-13",
+    "test-name-many2-12",
+    "test-name-many2-11",
+    "test-name-many2-10",
+    "test-name-many2-09",
+    "test-name-many2-08",
+    "test-name-many2-07",
+    "test-name-many2-06",
+    "test-name-many2-05",
+    "test-name-many2-04",
+    "test-name-many2-03",
+    "test-name-many2-02",
+    "test-name-many2-01"
+  ]
+
   auix_resource_metadata :product_location, context: Inventory, schema: ProductLocation do
     field(:products, omitted: true)
   end
@@ -16,7 +39,7 @@ defmodule Aurora.Uix.Test.Web.AssociationMany2OneSelectorAtomTest do
   end
 
   auix_resource_metadata(:product, context: Inventory, schema: Product) do
-    field(:product_location_id, option_label: :name)
+    field(:product_location_id, option_label: :name, order_by: [desc: :name])
   end
 
   # When you define a link in a test, add a line to test/support/app_web/router.exs
@@ -107,5 +130,30 @@ defmodule Aurora.Uix.Test.Web.AssociationMany2OneSelectorAtomTest do
              "select[id^='auix-field-product-product_location_id-'][id$='-form'] option[selected][value='#{location_id_2}']",
              name_2
            )
+  end
+
+  test "Test selector order by", %{conn: conn} do
+    location_id =
+      20
+      |> create_sample_product_locations(:many2)
+      |> get_in(["id_1", Access.key!(:id)])
+
+    product_id =
+      1
+      |> create_sample_products(:test, %{product_location_id: location_id})
+      |> get_in([Access.key!("id_test-1"), Access.key!(:id)])
+
+    {:ok, _view, html} =
+      live(
+        conn,
+        "/association-many_to_one_selector-atom-products/#{product_id}/edit"
+      )
+
+    assert html
+           |> Floki.find(
+             "select[id^='auix-field-product-product_location_id-'][id$='-form'] option"
+           )
+           |> Enum.map(&(&1 |> Floki.text() |> String.trim()))
+           |> Enum.filter(&String.starts_with?(&1, "test-name-many2-")) == @test_names
   end
 end

--- a/test/cases_live/order_by_layout_test.exs
+++ b/test/cases_live/order_by_layout_test.exs
@@ -1,0 +1,94 @@
+defmodule Aurora.Uix.Test.Web.OrderByLayoutTest do
+  use Aurora.Uix.Test.Web, :aurora_uix_for_test
+  use Aurora.Uix.Test.Web.UICase, :phoenix_case
+
+  alias Aurora.Uix.Test.Inventory
+  alias Aurora.Uix.Test.Inventory.Product
+  alias Aurora.Uix.Test.Repo
+
+  @shuffled_references [
+    "test_order-11",
+    "test_order-03",
+    "test_order-20",
+    "test_order-08",
+    "test_order-14",
+    "test_order-05",
+    "test_order-19",
+    "test_order-17",
+    "test_order-02",
+    "test_order-10",
+    "test_order-16",
+    "test_order-07",
+    "test_order-12",
+    "test_order-09",
+    "test_order-18",
+    "test_order-04",
+    "test_order-13",
+    "test_order-06",
+    "test_order-01",
+    "test_order-15"
+  ]
+
+  @test_references [
+    "Item test_order-01",
+    "Item test_order-02",
+    "Item test_order-03",
+    "Item test_order-04",
+    "Item test_order-05",
+    "Item test_order-06",
+    "Item test_order-07",
+    "Item test_order-08",
+    "Item test_order-09",
+    "Item test_order-10",
+    "Item test_order-11",
+    "Item test_order-12",
+    "Item test_order-13",
+    "Item test_order-14",
+    "Item test_order-15",
+    "Item test_order-16",
+    "Item test_order-17",
+    "Item test_order-18",
+    "Item test_order-19",
+    "Item test_order-20"
+  ]
+
+  auix_resource_metadata(:product,
+    context: Inventory,
+    schema: Product,
+    order_by: :reference
+  )
+
+  # When you define a link in a test, add a line to test/support/app_web/router.exs
+  # See section `Including cases_live tests in the test server` in the README.md file.
+  auix_create_ui(link_prefix: "order-by-metadata-") do
+    index_columns(:product, [:id, :reference, :name, :cost], order_by: :name)
+  end
+
+  test "Test UI default order", %{conn: conn} do
+    create_shuffled_products(@shuffled_references)
+
+    {:ok, _view, html} = live(conn, "/order-by-layout-products")
+    assert html =~ "Listing Products"
+
+    assert html
+           |> Floki.find("table tbody tr td:nth-of-type(3)")
+           |> Enum.map(&Floki.text/1)
+           |> Enum.filter(&String.starts_with?(&1, "Item test_order-")) == @test_references
+  end
+
+  @spec create_shuffled_products(list()) :: :ok
+  defp create_shuffled_products(reference_ids) do
+    Enum.each(reference_ids, fn reference_id ->
+      name = "Item #{reference_id}"
+      description = "This is the item #{reference_id} as described."
+
+      Repo.insert(%Product{
+        reference: Ecto.UUID.generate() |> to_string() |> String.slice(0, 30),
+        name: name,
+        description: description,
+        cost: :rand.uniform_real() * 100 + 123,
+        quantity_initial: :rand.uniform_real() * 20
+      })
+    end)
+  end
+end

--- a/test/cases_live/order_by_metadata_test.exs
+++ b/test/cases_live/order_by_metadata_test.exs
@@ -1,0 +1,94 @@
+defmodule Aurora.Uix.Test.Web.OrderByMetadataTest do
+  use Aurora.Uix.Test.Web, :aurora_uix_for_test
+  use Aurora.Uix.Test.Web.UICase, :phoenix_case
+
+  alias Aurora.Uix.Test.Inventory
+  alias Aurora.Uix.Test.Inventory.Product
+  alias Aurora.Uix.Test.Repo
+
+  @shuffled_references [
+    "test_order-11",
+    "test_order-03",
+    "test_order-20",
+    "test_order-08",
+    "test_order-14",
+    "test_order-05",
+    "test_order-19",
+    "test_order-17",
+    "test_order-02",
+    "test_order-10",
+    "test_order-16",
+    "test_order-07",
+    "test_order-12",
+    "test_order-09",
+    "test_order-18",
+    "test_order-04",
+    "test_order-13",
+    "test_order-06",
+    "test_order-01",
+    "test_order-15"
+  ]
+
+  @test_references [
+    "item_test_order-01",
+    "item_test_order-02",
+    "item_test_order-03",
+    "item_test_order-04",
+    "item_test_order-05",
+    "item_test_order-06",
+    "item_test_order-07",
+    "item_test_order-08",
+    "item_test_order-09",
+    "item_test_order-10",
+    "item_test_order-11",
+    "item_test_order-12",
+    "item_test_order-13",
+    "item_test_order-14",
+    "item_test_order-15",
+    "item_test_order-16",
+    "item_test_order-17",
+    "item_test_order-18",
+    "item_test_order-19",
+    "item_test_order-20"
+  ]
+  auix_resource_metadata(:product,
+    context: Inventory,
+    schema: Product,
+    order_by: :reference
+  )
+
+  # When you define a link in a test, add a line to test/support/app_web/router.exs
+  # See section `Including cases_live tests in the test server` in the README.md file.
+  auix_create_ui(link_prefix: "order-by-metadata-") do
+    index_columns(:product, [:id, :reference, :name, :cost])
+  end
+
+  test "Test UI default order", %{conn: conn} do
+    create_shuffled_products(@shuffled_references)
+
+    {:ok, _view, html} = live(conn, "/order-by-metadata-products")
+    assert html =~ "Listing Products"
+
+    assert html
+           |> Floki.find("table tbody tr td:nth-of-type(2)")
+           |> Enum.map(&Floki.text/1)
+           |> Enum.filter(&String.starts_with?(&1, "item_test_order-")) == @test_references
+  end
+
+  @spec create_shuffled_products(list()) :: :ok
+  defp create_shuffled_products(reference_ids) do
+    Enum.each(reference_ids, fn reference_id ->
+      reference = "item_#{reference_id}"
+      name = "Item #{reference_id}"
+      description = "This is the item #{reference_id} as described."
+
+      Repo.insert(%Product{
+        reference: reference,
+        name: name,
+        description: description,
+        cost: :rand.uniform_real() * 100 + 123,
+        quantity_initial: :rand.uniform_real() * 20
+      })
+    end)
+  end
+end

--- a/test/support/app_web/router.ex
+++ b/test/support/app_web/router.ex
@@ -140,6 +140,16 @@ defmodule Aurora.Uix.Test.Web.Router do
       "handler-hooks-form-"
     )
 
+    Web.register_product_crud(
+      OrderByMetadataTest,
+      "order-by-metadata-"
+    )
+
+    Web.register_product_crud(
+      OrderByLayoutTest,
+      "order-by-layout-"
+    )
+
     ## You can create a file test/cases_live/-local-demo_test.exs
     ## With Aurora.Uix.Test.Web.LocalDemoTest module
     ## And then test its output in /local-demo-products

--- a/test/support/helper.ex
+++ b/test/support/helper.ex
@@ -73,14 +73,18 @@ defmodule Aurora.Uix.Test.Support.Helper do
   ## Returns
   list(ProductLocation.t()) - List of created product locations.
   """
-  @spec create_sample_product_locations(integer()) :: list(ProductLocation.t())
-  def create_sample_product_locations(locations_count) do
+  @spec create_sample_product_locations(integer(), atom() | nil) :: list(ProductLocation.t())
+  def create_sample_product_locations(locations_count, prefix \\ nil) do
+    length = locations_count |> to_string() |> String.length()
+
     1..locations_count
     |> Enum.map(fn index ->
+      reference_id = reference_id(prefix, index, length)
+
       %ProductLocation{
-        reference: "test-reference-#{index}",
-        name: "test-name-#{index}",
-        type: "test-type-#{index}"
+        reference: "test-reference-#{reference_id}",
+        name: "test-name-#{reference_id}",
+        type: "test-type-#{reference_id}"
       }
       |> Repo.insert()
       |> elem(1)


### PR DESCRIPTION
- Option `order_by` implemented at metadata level.
- Option `order_by` implemented at index_columns level (takes precedence over metadata)
- Option `order_by` implemented for one_to_many
- Option `order_by` implemented for selector of many_to_one
- Tests created.