### PR TITLE
Separate layout separate opts from trees

### DIFF
--- a/lib/aurora_uix/layout/blueprint.ex
+++ b/lib/aurora_uix/layout/blueprint.ex
@@ -556,7 +556,10 @@ defmodule Aurora.Uix.Layout.Blueprint do
       resource_config
       |> fields_order()
       |> Enum.reject(
-        &(get_in(resource_config, [:fields, &1, :type]) in [:many_to_one_association, :one_to_many_association])
+        &(get_in(resource_config, [:fields, &1, :type]) in [
+            :many_to_one_association,
+            :one_to_many_association
+          ])
       )
       |> Enum.map(&%{tag: :field, name: &1, inner_elements: [], opts: []})
 
@@ -575,7 +578,11 @@ defmodule Aurora.Uix.Layout.Blueprint do
       resource_config
       |> fields_order()
       |> Enum.reject(
-        &(get_in(resource_config, [:fields, &1, :type]) in [:many_to_one_association, :one_to_many_association]))
+        &(get_in(resource_config, [:fields, &1, :type]) in [
+            :many_to_one_association,
+            :one_to_many_association
+          ])
+      )
       |> Enum.map(&%{tag: :field, name: &1, inner_elements: [], opts: []})
 
     fields_layout_mode = Keyword.get(opts, :default_fields_layout, :stacked)
@@ -592,9 +599,17 @@ defmodule Aurora.Uix.Layout.Blueprint do
   end
 
   def build_default_layout_paths([], resource_config, _opts, layout_type),
-    do: TreePath.new(%{name: resource_config.name, tag: layout_type, config: [], opts: [], inner_elements: []})
+    do:
+      TreePath.new(%{
+        name: resource_config.name,
+        tag: layout_type,
+        config: [],
+        opts: [],
+        inner_elements: []
+      })
 
-  def build_default_layout_paths([%{} = paths], _resource_config, _opts, _layout_type), do: TreePath.new(paths)
+  def build_default_layout_paths([%{} = paths], _resource_config, _opts, _layout_type),
+    do: TreePath.new(paths)
 
   @doc """
   Parses a list of paths to handle sections based on the given layout type.
@@ -759,7 +774,8 @@ defmodule Aurora.Uix.Layout.Blueprint do
       |> Keyword.put(:sections_index, next_sections_index)
       |> Keyword.put(:tabs, tabs_info)
 
-    new_element = TreePath.change(element, %{config: new_config, inner_elements: new_inner_elements})
+    new_element =
+      TreePath.change(element, %{config: new_config, inner_elements: new_inner_elements})
 
     normalize_sections_and_tabs(
       elements,
@@ -808,7 +824,8 @@ defmodule Aurora.Uix.Layout.Blueprint do
         tab_index: next_tab_index
       )
 
-    new_element = TreePath.change(element, %{config: new_config, inner_elements: new_inner_elements})
+    new_element =
+      TreePath.change(element, %{config: new_config, inner_elements: new_inner_elements})
 
     normalize_sections_and_tabs(
       elements,

--- a/lib/aurora_uix/layout/build_layouts.ex
+++ b/lib/aurora_uix/layout/build_layouts.ex
@@ -1,0 +1,9 @@
+defmodule Aurora.Uix.Layout.BuildLayouts do
+  @moduledoc false
+
+  @doc false
+  @spec build(map()) :: map()
+  def build(_layout_paths) do
+    %{}
+  end
+end

--- a/lib/aurora_uix/layout/build_tree.ex
+++ b/lib/aurora_uix/layout/build_tree.ex
@@ -1,9 +1,0 @@
-defmodule Aurora.Uix.Layout.BuildTree do
-  @moduledoc false
-
-  @doc false
-  @spec build_tree(map(), map()) :: map()
-  def build_tree(_resource_metadata, _layout_path) do
-    %{}
-  end
-end


### PR DESCRIPTION
- Blueprint now produces TreePath types.
- In the create ui, separate the options from the layout definition tree.