### PR TITLE
Fix formatting and references in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,13 @@ Requires:
 
 ### Added
 
-- **Ash Framework Integration** (#208)[https://github.com/wadvanced/aurora_uix/pull/208]
+- **Ash Framework Integration** [#208](https://github.com/wadvanced/aurora_uix/pull/208)
   - Full support for Ash Framework as a backend alternative to Phoenix Contexts
   - Automatic field parsing, pagination, and embeds support
   - Support for custom Ash actions (read, create, update, destroy)
   - See `guides/core/ash_integration.md` for details
 
-- **Custom Action Support** (#214)[https://github.com/wadvanced/aurora_uix/pull/214]
+- **Custom Action Support** [#214](https://github.com/wadvanced/aurora_uix/pull/214)
   - Support for custom backend actions via resource metadata options
   - Custom Ash actions: `:ash_read_action`, `:ash_create_action`, `:ash_update_action`, etc.
   - Custom Context functions: `:ctx_list_function`, `:ctx_create_function`, etc.
@@ -61,7 +61,7 @@ Requires:
 
 ### Fixed
 
-- Record navigator incorrectly rendered in new entry forms (#213)
+- Record navigator incorrectly rendered in new entry forms [#213](https://github.com/wadvanced/aurora_uix/pull/223)
 - Failure to detect `embeds_one` or `embeds_many` in some cases
 - Error resolving default function in `:ctx` type backends
 - Missing HTML type assignment for certain field types


### PR DESCRIPTION
Updated links and formatting for Ash Framework and Custom Action Support entries. Fixed the reference for the record navigator issue.