### PR TITLE
fix: wrong styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,17 @@ Requires:
 
 ### CSS class changes
 
-_No changes in this release._
+- **`.auix-button` no longer carries structural rules** (`display`, `border-*`, `padding`, `font-*`).
+  Structure has moved to `.auix-button-default`, which is now auto-applied by the `<.button>`
+  component. Hosts that selected `.auix-button` to override padding or borders should switch
+  their selector to `.auix-button-default`.
+- **`.auix-button-default` is now a public/semi-public class.** Hosts that previously applied
+  `.auix-button` directly (without going through `<.button>`) will now receive only the color
+  rules. Add `.auix-button-default` explicitly to restore the structural styles.
+- **`.auix-index-all-action-button` lost its structural declarations** (previously duplicated
+  from `.auix-button`). Visible behaviour is identical when the button is rendered through
+  `<.button>` as intended, because `.auix-button-default` is auto-applied.
+
 
 
 ## [0.1.3] - 2026-02-15

--- a/guides/advanced/advanced_usage.md
+++ b/guides/advanced/advanced_usage.md
@@ -1160,7 +1160,7 @@ Aurora UIX themes follow a three-layer pattern:
 - Example: `BaseVariables` defines `--auix-padding-default`, `--auix-border-radius-default`, etc.
 
 **Layer 3: Base Rules**
-- Defines all CSS class rules (`.auix-button`, `.auix-input`, etc.)
+- Defines all CSS class rules (`.auix-button-default`, `.auix-button`, `.auix-input`, etc.)
 - Uses the color variables from Layer 1
 - Shared across all themes
 - Delegated through pattern matching for composition
@@ -1425,11 +1425,13 @@ defmodule MyApp.Themes.CompactTheme do
   
   alias Aurora.Uix.Templates.Basic.Themes.BaseVariables
 
-  # Override the button styling
+  # Because `<.button>` applies `.auix-button-default` as its structural base,
+  # customising it here propagates to every button variant (primary, alt, index-bar)
+  # without touching color rules.
   @impl true
   def rule(:_auix_button_default) do
     """
-    .-auix-button-default {
+    .auix-button-default {
       display: flex;
       flex-direction: row;
       align-items: center;

--- a/guides/core/layouts.md
+++ b/guides/core/layouts.md
@@ -559,7 +559,7 @@ defmodule MyAppWeb.ProductViews do
 
   def cancel_action(assigns) do
     ~H"""
-    <.auix_back class="auix-button auix-button--secondary">
+    <.auix_back class="auix-button--alt">
       Cancel
     </.auix_back>
     """
@@ -586,7 +586,7 @@ defmodule MyAppWeb.ProductViews do
       patch={"/#{@auix.uri_path}/new?duplicate_from=#{@auix.entity.id}"}
       name={"auix-duplicate-#{@auix.module}"}
     >
-      <.button class="auix-button--secondary">Duplicate Product</.button>
+      <.button class="auix-button--alt">Duplicate Product</.button>
     </.auix_link>
     """
   end
@@ -683,7 +683,7 @@ This helper handles both single and composite primary keys:
 **Action Styling:**
 - Use `auix-*` CSS classes for consistent styling
 - Row action icons: `auix-icon-size-5` with context classes (`auix-icon-info`, `auix-icon-safe`, `auix-icon-danger`)
-- Buttons: `auix-button`, `auix-button--secondary`, `auix-button--alt`
+- Buttons: `auix-button` (primary, default), `auix-button--alt` (secondary), `auix-index-all-action-button` (index-bar select-all). Pick exactly one — `<.button>` already supplies the structural base.
 
 ### Action Modification Under the Hood
 

--- a/guides/core/styling.md
+++ b/guides/core/styling.md
@@ -388,6 +388,26 @@ Common visual adjustments and the minimal set of variables to override:
 | Tighter list rows | `--auix-gap-minimal`, `--auix-padding-minimal`, `--auix-margin-default` |
 | Bolder labels | `--auix-font-weight-bold`, `--auix-color-text-label` |
 
+## Rule: one color class per element
+
+An element may carry multiple CSS classes, but at most one of them may set `color`,
+`background-color`, or `border-color`. The classes ending in a BEM modifier (`--alt`,
+`--errors`, `--iconized`) and the named full-variant classes (`.auix-index-all-action-button`)
+are the color-bearing classes. Structural bases like `.auix-button-default` and size utilities
+like `.auix-icon-size-5` are color-neutral and safe to combine freely with a color class.
+
+When adding a brand variant, mirror the same pattern — declare a single class that sets
+color rules only (no `padding`, `border-width`, `font-*`, etc.) and let the component's
+structural base handle the rest:
+
+```css
+/* ✅ Color-only variant — safe to layer on top of .auix-button-default */
+.my-host-app .auix-button--promo {
+  background-color: var(--my-brand-promo);
+  color: var(--my-brand-promo-text);
+}
+```
+
 ## Escape hatch: semantic class overrides
 
 When a variable override cannot express the desired structural change — for example, switching
@@ -405,8 +425,10 @@ a component's flex direction or inserting an additional layout layer — you can
 
 | Class | Used by | Tokens it consumes |
 |---|---|---|
-| `.auix-button` | Primary action button | `--auix-border-width-default`, `--auix-border-style-default`, `--auix-border-radius-small`, `--auix-padding-minimal`, `--auix-font-size-caption`, `--auix-font-weight-bold`, `--auix-color-button-bg`, `--auix-color-button-text`, `--auix-color-bg-hover--reverted`, `--auix-color-text-on-accent-active`, `--auix-opacity-75` |
-| `.auix-button--alt` | Secondary / alternative button | `--auix-color-button-alt-bg`, `--auix-color-button-alt-text`, `--auix-color-button-alt-border`, `--auix-color-bg-hover`, `--auix-color-text-inactive` |
+| `.auix-button-default` | Structural base auto-applied to every `<.button>` (layout, border, padding, typography — no color) | `--auix-border-width-default`, `--auix-border-style-default`, `--auix-border-radius-small`, `--auix-padding-minimal`, `--auix-font-size-caption`, `--auix-font-weight-bold` |
+| `.auix-button` | Primary color variant (default for `<.button>` when no variant is passed) | `--auix-color-button-bg`, `--auix-color-button-text`, `--auix-color-bg-hover--reverted`, `--auix-color-text-on-accent-active`, `--auix-opacity-75` |
+| `.auix-button--alt` | Secondary / alternative button (caller-supplied via `class=`; sits on top of the auto-applied `.auix-button-default` — never combine with `.auix-button`) | `--auix-color-button-alt-bg`, `--auix-color-button-alt-text`, `--auix-color-button-alt-border`, `--auix-color-bg-hover`, `--auix-color-text-inactive` |
+| `.auix-index-all-action-button` | Select-all / deselect-all index-bar variant — color only; replaces, not supplements, `.auix-button` | `--auix-color-button-bg`, `--auix-color-button-text` |
 | `.auix-button--iconized` | Icon-only button (no border) | `--auix-color-bg-secondary` (hover) |
 | `.auix-button-badge` | Embedded-relation count badge | `--auix-font-size-small`, `--auix-border-radius-round`, `--auix-padding-minimal` |
 | `.auix-input` | Text / number / date inputs | `--auix-padding-minimal`, `--auix-border-width-default`, `--auix-border-style-default`, `--auix-border-radius-small`, `--auix-color-input-text`, `--auix-font-size-caption` |
@@ -438,6 +460,9 @@ a component's flex direction or inserting an additional layout layer — you can
 Scope overrides to a specific host section to avoid leaking into unrelated components:
 
 ```css
+/* Overrides the primary color variant only; sibling variants (.auix-button--alt,
+   .auix-index-all-action-button) are unaffected and need their own override if
+   matching brand color is desired there. */
 .my-host-app .auix-button {
   background-color: var(--my-brand);
 }

--- a/lib/aurora_uix/parsers/common.ex
+++ b/lib/aurora_uix/parsers/common.ex
@@ -68,11 +68,9 @@ defmodule Aurora.Uix.Parsers.Common do
     |> List.last()
   end
 
-  def option_value(_parsed_opts, %{schema: module}, _opts, :name) do
-    module
-    |> Module.split()
-    |> List.last()
-    |> CommonHelper.capitalize()
+  def option_value(parsed_opts, resource_config, opts, :name) do
+    has_key? = Keyword.has_key?(opts, :name)
+    process_name(parsed_opts, resource_config, opts, has_key?)
   end
 
   def option_value(_parsed_opts, %{schema: module}, _opts, :source),
@@ -81,13 +79,43 @@ defmodule Aurora.Uix.Parsers.Common do
   def option_value(_parsed_opts, %{schema: module}, _opts, :source_key),
     do: :source |> module.__schema__() |> CommonHelper.safe_atom()
 
-  def option_value(_parsed_opts, %{schema: module}, _opts, :title) do
-    :source
-    |> module.__schema__()
-    |> CommonHelper.capitalize()
+  def option_value(parsed_opts, resource_config, opts, :title) do
+    has_key? = Keyword.has_key?(opts, :title)
+    process_title(parsed_opts, resource_config, opts, has_key?)
   end
 
   def option_value(_parsed_opts, %{schema: module}, _opts, :primary_key) do
     module.__schema__(:primary_key)
+  end
+
+  ## PRIVATE
+  @spec process_name(map(), map(), keyword(), boolean()) :: binary()
+  defp process_name(_parsed_opts, _resource_config, opts, true) do
+    case opts[:name] do
+      nil -> ""
+      value -> value
+    end
+  end
+
+  defp process_name(_parsed_opts, %{schema: module}, _opts, false) do
+    module
+    |> Module.split()
+    |> List.last()
+    |> CommonHelper.capitalize()
+  end
+
+  @spec process_title(map(), map(), keyword(), boolean()) :: binary()
+  defp process_title(_parsed_opts, _resource_config, opts, true) do
+    case opts[:title] do
+      # Nil will be blank so title: nil is valid
+      nil -> ""
+      value -> value
+    end
+  end
+
+  defp process_title(_parsed_opts, %{schema: module}, _opts, false) do
+    :source
+    |> module.__schema__()
+    |> CommonHelper.capitalize()
   end
 end

--- a/lib/aurora_uix/templates/basic/components/core_components.ex
+++ b/lib/aurora_uix/templates/basic/components/core_components.ex
@@ -234,7 +234,12 @@ defmodule Aurora.Uix.Templates.Basic.CoreComponents do
       <.button phx-click="go" class="ml-2">Send!</.button>
   """
   attr(:type, :string, default: nil)
-  attr(:class, :string, default: nil)
+
+  attr(:class, :string,
+    default: "auix-button",
+    doc: "color/variant class; one of auix-button, auix-button--alt, auix-index-all-action-button"
+  )
+
   attr(:rest, :global, include: ~w(disabled form name value))
 
   slot(:inner_block, required: true)
@@ -244,7 +249,7 @@ defmodule Aurora.Uix.Templates.Basic.CoreComponents do
     ~H"""
     <button
       type={@type}
-      class={["auix-button", @class]}
+      class={["auix-button-default", @class]}
       {@rest}
     >
       {render_slot(@inner_block)}

--- a/lib/aurora_uix/templates/basic/components/core_components.ex
+++ b/lib/aurora_uix/templates/basic/components/core_components.ex
@@ -86,7 +86,7 @@ defmodule Aurora.Uix.Templates.Basic.CoreComponents do
                     aria-label={gettext("close")}
                   >
                     <.icon
-                    name="hero-x-mark-solid" class="auix-icon-size-button" />
+                    name="hero-x-mark" class="auix-icon-size-button" />
                   </button>
                 </div>
                 <div id={"#{@id}-content"}>
@@ -511,7 +511,7 @@ defmodule Aurora.Uix.Templates.Basic.CoreComponents do
         navigate={@navigate}
         class="auix-back-link"
       >
-        <.icon name="hero-arrow-left-solid" class="auix-icon-size-3" />
+        <.icon name="hero-arrow-left" class="auix-icon-size-3" />
         {render_slot(@inner_block)}
       </.link>
     </div>

--- a/lib/aurora_uix/templates/basic/components/routing_components.ex
+++ b/lib/aurora_uix/templates/basic/components/routing_components.ex
@@ -109,7 +109,7 @@ defmodule Aurora.Uix.Templates.Basic.RoutingComponents do
         class="auix-back-link"
         {@rest}
       >
-        <.icon name="hero-arrow-left-solid" class="auix-icon-size-3" />
+        <.icon name="hero-arrow-left" class="auix-icon-size-3" />
         {render_slot(@inner_block)}
       </a>
     </div>

--- a/lib/aurora_uix/templates/basic/themes/base.ex
+++ b/lib/aurora_uix/templates/basic/themes/base.ex
@@ -1536,10 +1536,20 @@ defmodule Aurora.Uix.Templates.Basic.Themes.Base do
     """
     /* auix-index-all-action-button */
 
-    #{import_rule(:auix_button__alt, :auix_index_all_action_button)}
-
     .auix-index-all-action-button {
-      gap: var(--auix-gap-default);
+      background-color: var(--auix-color-button-alt-bg);
+      color: var(--auix-color-button-alt-text);
+      border-color: var(--auix-color-button-alt-border);
+    }
+
+    .auix-index-all-action-button:disabled {
+      background-color: var(--auix-color-bg-backdrop);
+      color: var(--auix-color-text-inactive);
+    }
+
+    .auix-index-all-action-button:hover {
+      background-color: var(--auix-color-bg-hover);
+      cursor: pointer;
     }
 
     """

--- a/lib/mix/tasks/uix/gen/stylesheet.ex
+++ b/lib/mix/tasks/uix/gen/stylesheet.ex
@@ -255,11 +255,19 @@ defmodule Mix.Tasks.Auix.Gen.Stylesheet do
     layer_close = "  }\n}\n"
 
     example =
-      "\n/* Semantic class override example — paste outside the @layer above to use.\n" <>
-        ".my-host-app .auix-button {\n" <>
-        "  background-color: var(--my-brand);\n" <>
-        "}\n" <>
-        "*/\n"
+      """
+        /* Might need to uncomment this rule to let border of container behave as
+          designed by aurora_uix */
+        .auix-modal-focus-wrap, .auix-show-container, .auix-show-content {
+          border: revert; 
+        }
+
+        /* Semantic class override example — paste outside the @layer above to use.
+        .my-host-app .auix-button { 
+          background-color: var(--my-brand);
+        }
+        */
+      """
 
     header <> layer_open <> sections <> "\n" <> layer_close <> example
   end


### PR DESCRIPTION
## Summary

This PR addresses several styling inconsistencies and related fixes in the AuroraUIX component layer.

## Commits

### fix: resolve multi-class color violation on button component
The `<.button>` component was hard-coding `auix-button` as its base class, causing a double-color-class element whenever a caller passed a variant like `auix-index-all-action-button` or `auix-button--alt`. Both classes set background-color/color/border-color on the same element, making the cascade non-deterministic.
- Emit `auix-button-default` (structure-only) as the permanent base class so the component always contributes exactly one structural class.
- Default `@class` to `auix-button` so existing color-less callers keep their primary appearance unchanged.
- Rewrite `rule(:auix_index_all_action_button)` in `base.ex` to carry color declarations only; CSS regenerated via `mix auix.gen.stylesheet`.

### docs: update button class guidance for structural/color separation
Document the split of `.auix-button` into a structural base (`.auix-button-default`, auto-applied by `<.button>`) and color-only variants. Update CHANGELOG, styling reference table, layout examples, and theming guide.

### feat: support user-supplied name and title overrides in Parsers.Common
Refactor `option_value/4` for `:name` and `:title` keys to check for caller-provided values in opts before falling back to schema-derived defaults. Extracts `process_name/4` and `process_title/4` private helpers for clarity. Adds `@spec` for both helpers.

### fix: add border reset hint to generated stylesheet comment
Include a commented-out `border: revert` rule for auix modal/show containers in the generated stylesheet, giving hosts a ready-made escape hatch when container borders misbehave after applying a custom theme.

### fix: switch icon variants from solid to outline in core and routing components
Replace `hero-x-mark-solid` and `hero-arrow-left-solid` with their outline counterparts to align with the project convention of using outline Heroicons.