### PR TITLE
fix: remove raise from the fields parser of ash for atom

### DIFF
--- a/lib/aurora_uix/integration/ash/fields_parser.ex
+++ b/lib/aurora_uix/integration/ash/fields_parser.ex
@@ -28,6 +28,8 @@ defmodule Aurora.Uix.Integration.Ash.FieldsParser do
   alias Aurora.Uix.Integration.FieldsParser, as: CommonFieldsParser
   alias Aurora.Uix.Resource
 
+  require Logger
+
   @doc """
   Parses all attributes from an Ash resource into Field structs.
 
@@ -358,12 +360,16 @@ defmodule Aurora.Uix.Integration.Ash.FieldsParser do
          constraints: constraints
        })
        when resource_type in [Ash.Type.Atom, Ash.Type.Atom.EctoType] do
-    if Keyword.has_key?(constraints, :one_of),
-      do: :select,
-      else:
-        raise(
-          "Field ':#{attrs.key}' of '#{attrs.resource_schema}' has invalid ':atom' type, it can only be used in conjuntion of ':one_of' constraint. Change to :string"
-        )
+    if Keyword.has_key?(constraints, :one_of) do
+      :select
+    else
+      Logger.warning("""
+              Field ':#{attrs.key}' of '#{attrs.resource_schema}' has invalid ':atom' type, it makes sense to be used in conjuntion of ':one_of' constraint.
+              Setting values of NON existant atoms will raise an error on the host runtime. 
+      """)
+
+      :text
+    end
   end
 
   defp field_html_type(_attrs, %{embedded?: true}), do: :unimplemented

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Aurora.Uix.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/wadvanced/aurora_uix"
-  @version "0.1.4-rc.6"
+  @version "0.1.4-rc.7"
 
   def project do
     [


### PR DESCRIPTION
Previous version raises an error when a field is atom type and does not have a constraint one_of.

That decision was based on the fact that any intent of save an string that is not possible to be converted to atom with String.to_existing_atom will raise on the host. 

It should be the host responsibility to solve that situations.