### PR TITLE
feat: v0.1.5 rc.3

### DIFF
--- a/.claude/skills/do-pr/SKILL.md
+++ b/.claude/skills/do-pr/SKILL.md
@@ -7,12 +7,11 @@ Create a pull request for the current branch. Run every step in order. If a step
 
 ## 1. Preconditions
 
-Run both checks. Stop and report if any fails.
-
 - Current branch is not `main`:
-  - `git rev-parse --abbrev-ref HEAD` must NOT print `main`.
-- All changes are committed:
-  - `git status --porcelain` must print nothing.
+  - `git rev-parse --abbrev-ref HEAD` must NOT print `main`. Stop if it does.
+
+Do NOT require a clean working tree here — Step 2's `gate` commits any remaining
+working-tree changes into conventional commits.
 
 ## 2. Quality gate
 
@@ -24,53 +23,139 @@ Run 'mix test' if any error, report the errors and ask the user if the task shou
 
 ## 4. Push
 
+Push is **mandatory on every invocation**, including re-runs where the PR already
+exists — the PR description is built from local commits, so origin must carry them
+first.
+
 ```
 git push -u origin <current-branch>
 ```
 
-If push fails, stop and report. Never use `--force` or `--no-verify`.
+Then confirm the branch is fully pushed — these two SHAs must be equal:
+
+```
+git rev-parse HEAD
+git rev-parse origin/<current-branch>
+```
+
+If push fails or the SHAs differ, stop and report. Never use `--force` or
+`--no-verify`.
 
 ## 5. Build the PR title
 
 Apply these rules to the current branch name:
 
 1. Strip any leading `<username>/` or `<username>-` prefix (everything up to and including the first `/` or `-`).
-2. Take the first remaining token (split on `-` or `_`). If it matches one of `feat|fix|build|refactor|docs|chore|test|perf`, use it as `<type>` and remove it. Otherwise default `<type>` to `feat`.
-3. Replace remaining `-` and `_` with spaces. This is `<description>`.
-4. Final title: `<type>: <description>`.
+2. If the next segment is purely numeric (an issue number, e.g. `365/…`), strip it too — including its trailing `/` or `-`.
+3. Take the first remaining token (split on `-` or `_`). If it matches one of `feat|fix|build|refactor|docs|chore|test|perf`, use it as `<type>` and remove it. Otherwise default `<type>` to `feat`.
+4. Replace remaining `-` and `_` with spaces. This is `<description>`.
+5. Final title: `<type>: <description>`.
 
 Examples:
+- `federico/365/name-fields-components` → `feat: name fields components`
+- `federico/338/refactor-rename-table` → `refactor: rename table`
 - `federico/implement_user_profile` → `feat: implement user profile`
 - `federicoalcantara-fix-login-bug` → `fix: login bug`
 - `federico/refactor_auth` → `refactor: auth`
 
 ## 6. Build the PR body
 
-Use this exact template, filled from `git log main..HEAD --pretty=format:"%s"`:
+Write a **prose Summary that describes the change — not the commit log.** Do NOT
+copy commit subjects verbatim; a reviewer who has not seen the commits must be
+able to understand the PR from the body alone.
+
+**Gather context from the diff, not just the subjects:**
+
+- `git log main..HEAD --pretty=format:"%s"` — commit subjects, for orientation only.
+- `git diff main...HEAD --stat` — files touched and overall scope.
+- Read the actual diff for the substantive changes whenever the subjects are terse
+  (e.g. `ai: update skill files` tells a reviewer nothing).
+
+**Write the Summary as 3–6 bullets:**
+
+- Each bullet states *what* changed and, where non-obvious, *why*.
+- **Group related commits into a single bullet.** Do NOT emit one bullet per
+  commit.
+- Reference concrete artifacts — module, file, field, and function names in
+  backticks — so each bullet is self-explanatory.
+
+Good vs. bad bullets:
 
 ```
+❌ - ai: update do-pr and pr-from-issue skill files
+✅ - Rewrites `do-pr` Step 6 so PR summaries are prose derived from the diff
+     instead of copied commit subjects, and drops the boilerplate Test plan section
+```
+
+**Wrap the generated content in the managed-region markers.** These two visible
+blockquote lines delimit the block `do-pr` owns; reviewers add their own notes
+*outside* them and a later re-run refreshes only what is *between* them (see
+Step 7). Compose the whole block into a body file (`git status` is clean, so use
+the scratchpad or a temp file):
+
+```
+> 🤖 **GENERATED-DESCRIPTION:START** — auto-generated; edit above or below, never inside.
+
 ## Summary
-- <commit subject 1>
-- <commit subject 2>
+- <prose bullet 1>
+- <prose bullet 2>
 - ...
 
-## Test plan
-- [ ] mix consistency
-- [ ] mix test
+> 🤖 **GENERATED-DESCRIPTION:END**
 ```
 
-One bullet per commit (subject line only, no body).
+**Optional issue reference.** If a caller (e.g. the `pr-from-issue` skill) invokes
+this skill with an issue number `<n>`, add a blank line and `Closes #<n>` **inside
+the block**, right before the `GENERATED-DESCRIPTION:END` marker. When no issue
+number is passed, do not add a `Closes` line.
 
-## 7. Create the PR
+## 7. Create or update the PR
+
+**Sync guard (both paths).** The PR body describes local commits, so the branch
+must be fully pushed before it is written. Run `git push -u origin
+<current-branch>`, then verify `git rev-parse HEAD` equals `git rev-parse
+origin/<current-branch>`. If they differ, stop — do NOT create or update the PR.
+
+Check whether the branch already has a PR: `gh pr view --json url`.
+
+### No PR yet — create
+
+The body is the marker-wrapped block from Step 6 (the whole body file). Then:
 
 ```
-gh pr create --base main --title "<title>" --body "$(cat <<'EOF'
-<body>
-EOF
-)"
+gh pr create --base main --title "<title>" --body-file <body-file>
 ```
 
 Print the PR URL returned by `gh`.
+
+### PR already exists — refresh in place
+
+Refresh **only the text between the markers**, preserving everything a reviewer
+wrote above `GENERATED-DESCRIPTION:START` or below `GENERATED-DESCRIPTION:END`.
+
+1. Fetch the live body (strip the CRLF that `gh` injects):
+   ```
+   gh pr view --json body --jq .body | tr -d '\r' > live_body
+   ```
+2. **Both markers must be present.** If either is missing, do NOT touch the body
+   — report the PR URL and that the description was left unchanged, then stop:
+   ```
+   grep -qF 'GENERATED-DESCRIPTION:START' live_body \
+     && grep -qF 'GENERATED-DESCRIPTION:END' live_body
+   ```
+3. Carve out the reviewer-owned regions verbatim:
+   ```
+   awk '/GENERATED-DESCRIPTION:START/{exit} {print}' live_body > prefix   # before START
+   awk 'p{print} /GENERATED-DESCRIPTION:END/{p=1}'   live_body > suffix   # after END
+   ```
+4. Rebuild the managed block via Step 6 into `block` (fresh Summary from the
+   current commits, wrapped in both markers).
+5. Reassemble and update:
+   ```
+   cat prefix block suffix > new_body
+   gh pr edit --body-file new_body
+   ```
+   Report "description refreshed" and print the PR URL.
 
 ## Forbidden
 
@@ -78,3 +163,8 @@ Print the PR URL returned by `gh`.
 - `--no-verify` on any git command
 - Amending an already-pushed commit
 - Creating a PR while preconditions or precommit fail
+- Modifying the PR body when either `GENERATED-DESCRIPTION` marker is absent
+- Altering any content outside the `GENERATED-DESCRIPTION` markers, or the PR title
+- Creating or updating a PR description while local `HEAD` is ahead of
+  `origin/<current-branch>` (unpushed commits)
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,22 @@ Requires:
 
 ### Added
 
+- **Per-layout custom field renderers**
+  - `Aurora.Uix.Field` gains three per-layout renderer options — `index_renderer`, `edit_renderer`,
+    and `show_renderer` — alongside the existing generic `renderer`.
+  - The form (edit) and show layouts use `edit_renderer`/`show_renderer` when set and otherwise fall
+    back to `renderer`, preserving existing behavior. Index columns, which previously had no custom
+    renderer, honor `index_renderer` with no fallback to `renderer`.
+  - Configurable via `field/2` options or index column keyword lists, e.g.
+    `index_columns :product, [name: [index_renderer: &upcase_name/1]]`.
+
 - **Ash calculations and aggregates support in `FieldsParser`**
   - `FieldsParser` now discovers and includes Ash calculations and aggregates alongside
     attributes when building the field map for a resource, so computed and aggregated
-    fields are automatically available in generated UIs without manual configuration.
+    fields are automatically available in generated UIs without manual configuration on
+    ash backend.
   - `field_type/2` clauses added for all `Ash.Resource.Aggregate` kinds:
     `count` -> `:integer`, `exists` -> `:boolean`, `sum / max / min / avg` -> `:float`.
-  - Internal `map_from_struct/1` helper preserves the `__struct__` key so type-dispatch
-    pattern matches on aggregate/calculation structs remain accurate.
 
 - **Runtime component override mechanism**
   - `Aurora.Uix.ComponentsResolver` and `Aurora.Uix.ComponentsResolverHelper` — macro-based system enabling per-function component overrides resolved at call time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,17 @@ Requires:
 - `guides/customization/theming.md` — guide for authoring custom registered themes
 - Updated internal references across all existing core and advanced guides to point to the new customization paths
 
+- **Ash generated fields (calculations/aggregates) auto-loaded in generated layouts**
+  - Fields tagged as generated (`field.data == %{generated: true}`, i.e. Ash calculations/aggregates) referenced in
+    index/form/show layouts are now automatically added to the resource's Ash `load` list, alongside association preloads.
+    Resources no longer need `prepare build(load: :summary)` (or similar) on their read action purely to display a
+    calculation/aggregate that is only referenced through a layout.
+  - `auix_preloads/0` now returns a mixed list per resource (bare atoms for generated fields, `{name, nested}` tuples
+    for associations), e.g. `%{post: [:summary, comment: [], author: [...]]}`.
+  - `Aurora.Uix.Templates.Basic.Helpers.extract_association_preload/1` updated to tolerate bare-atom preload entries.
+  - **Limitation**: only argument-less calculations/aggregates are auto-loaded (`[:summary]`). Calculations that take
+    arguments still require an explicit `prepare build(load: [summary: %{arg: ...}])` on the resource's read action —
+    this feature composes with (does not replace) that mechanism.
 
 ## [0.1.4] - 2026-06-07
 

--- a/guides/core/layouts.md
+++ b/guides/core/layouts.md
@@ -388,10 +388,23 @@ end
 **Relevant Field Options:**
 - `:readonly` — Make field read-only
 - `:hidden` — Hide field from UI
-- `:renderer` — Custom rendering function
+- `:renderer` — Custom rendering function (form/edit and show layouts)
+- `:index_renderer` — Custom rendering function for the index layout only
+- `:edit_renderer` — Custom rendering function for the form (edit) layout only
+- `:show_renderer` — Custom rendering function for the show layout only
 - `:length` — Input field character width
 - `:placeholder` — Placeholder text
 - `:option_label` — For select/radio fields
+
+Per-layout renderers are especially useful for index columns, which the generic `:renderer`
+does not cover:
+
+```elixir
+index_columns :product, [
+  :reference,
+  name: [index_renderer: &MyAppWeb.Helpers.product_name_link/1]
+]
+```
 
 > **Note:** Some field options are resolved from the field's `data` map and must be set in
 > `auix_resource_metadata` rather than inline in a layout (layouts do not accept these rendering

--- a/guides/core/resource_metadata.md
+++ b/guides/core/resource_metadata.md
@@ -286,7 +286,10 @@ Each field in the resource metadata is a `Aurora.Uix.Field` struct with the foll
 - `label` - Display label for the field (auto-generated from field name if not specified)
 - `placeholder` - Placeholder text for input fields
 - `html_id` - A unique HTML id for the field (auto-generated)
-- `renderer` - Optional custom rendering function or component
+- `renderer` - Optional custom rendering function or component, applied to the **form (edit)** and **show** layouts unless a more specific per-layout renderer is set
+- `index_renderer` - Optional custom rendering function or component, applied only to the **index** layout (does not fall back to `renderer`)
+- `edit_renderer` - Optional custom rendering function or component, applied only to the **form (edit)** layout (falls back to `renderer` when not set)
+- `show_renderer` - Optional custom rendering function or component, applied only to the **show** layout (falls back to `renderer` when not set)
 
 ### Validation and Constraints
 
@@ -415,9 +418,38 @@ end
 
 The `html_type` option overrides the automatic HTML type inference. The `renderer` option allows providing a custom function or component for rendering the field.
 
-A renderer set here applies everywhere the field appears. To override rendering for a single
-layout only, use [field-level options in the layout DSL](layouts.md#field-level-options). For
-the full catalog of rendering customization points, see
+### Per-layout renderers
+
+`renderer` applies to the **form (edit)** and **show** layouts. To render a field differently
+depending on the layout, use the per-layout renderer options — each is a 1-arity function (or
+component) that receives the render assigns and returns a `Phoenix.LiveView.Rendered.t()`:
+
+```elixir
+auix_resource_metadata :product, schema: MyApp.Product do
+  field :status,
+    index_renderer: &MyAppWeb.Helpers.status_badge/1,
+    edit_renderer: &MyAppWeb.Helpers.status_select/1,
+    show_renderer: &MyAppWeb.Helpers.status_label/1
+end
+```
+
+Precedence:
+
+- **index** layout — uses `index_renderer` if set, otherwise the default rendering. The index
+  layout never falls back to `renderer`.
+- **form (edit)** layout — uses `edit_renderer` if set, otherwise `renderer`, otherwise the
+  default rendering.
+- **show** layout — uses `show_renderer` if set, otherwise `renderer`, otherwise the default
+  rendering.
+
+The render assigns available to a renderer include `@field` (the `Aurora.Uix.Field` struct) and
+`@auix` (the render context, e.g. `@auix.entity` in show/index and `@auix.form` in the form
+layout); index renderers also receive the row `@entity`.
+
+A renderer set here applies wherever its layout renders the field. To override rendering for a
+single layout at the layout-definition site instead, use
+[field-level options in the layout DSL](layouts.md#field-level-options). For the full catalog of
+rendering customization points, see
 [Customizing & Extending Aurora UIX](../customization/customization.md#3-custom-field-rendering).
 
 ## Associations

--- a/guides/customization/customization.md
+++ b/guides/customization/customization.md
@@ -107,6 +107,10 @@ Three places to attach it:
 - **Layout DSL field options** (per-layout: `name: [renderer: ...]`) → [Layouts → Field-Level Options](../core/layouts.md#field-level-options)
 - **Template-level renderers** (whole-view generation) → [Advanced Usage](../advanced/advanced_usage.md#how-templates-work)
 
+The generic `renderer` covers the form (edit) and show layouts. For layout-specific control —
+including index columns, which `renderer` does not cover — use `index_renderer`, `edit_renderer`,
+and `show_renderer`. See [Per-layout renderers](../core/resource_metadata.md#per-layout-renderers).
+
 > #### Copyable inputs in custom renderers {: .warning}
 > A custom `renderer:` function bypasses Aurora UIX's automatic field-id wiring. If your
 > renderer uses `<.input copyable>`, two things are required:
@@ -163,7 +167,8 @@ The most-used field options, all configured in `auix_resource_metadata` (some al
 | `omitted` | Completely excluded from the UI | [Field Properties](../core/resource_metadata.md#presentation-state) |
 | `label` | Display label (auto-generated otherwise) | [Display and Interaction](../core/resource_metadata.md#display-and-interaction) |
 | `placeholder` | Input placeholder text | [Display and Interaction](../core/resource_metadata.md#display-and-interaction) |
-| `renderer` | Custom rendering function/component | [Custom Field Types](../core/resource_metadata.md#custom-field-types-and-rendering) |
+| `renderer` | Custom rendering function/component (form/edit + show) | [Custom Field Types](../core/resource_metadata.md#custom-field-types-and-rendering) |
+| `index_renderer` / `edit_renderer` / `show_renderer` | Per-layout custom rendering function/component | [Per-layout renderers](../core/resource_metadata.md#per-layout-renderers) |
 | `option_label` | Label source for select dropdowns (atom or function) | [Many-to-One](../core/resource_metadata.md#many-to-one-belongs_to) |
 | `order_by` | Sort order for association options / lists | [Query Options](../core/resource_metadata.md#query-options-for-many-to-one) |
 | `where` | Filter for association options / lists | [Query Options](../core/resource_metadata.md#query-options-for-many-to-one) |

--- a/lib/aurora_uix/field.ex
+++ b/lib/aurora_uix/field.ex
@@ -8,7 +8,14 @@ defmodule Aurora.Uix.Field do
     - `type` (`atom`) - The type of the field, it is read from the source and SHOULDN'T be change.
     - `html_type` (`binary`) - The HTML type of the field (e.g., `:text`, `:number`, `:date`).
     - `html_id` (`binary`) - A unique html id for the field.
-    - `renderer` (`function`) - A custom rendering function for the field.
+    - `renderer` (`function`) - A custom rendering function for the field, used for the form (edit)
+      and show layouts unless a more specific `edit_renderer`/`show_renderer` is provided.
+    - `index_renderer` (`function`) - A custom rendering function used only for the index layout.
+      Index columns do not fall back to `renderer`.
+    - `edit_renderer` (`function`) - A custom rendering function used only for the form (edit) layout.
+      Falls back to `renderer` when not set.
+    - `show_renderer` (`function`) - A custom rendering function used only for the show layout.
+      Falls back to `renderer` when not set.
     - `data` (`any`) - A general purpose field.
         Template parser expect specific format for this data, according to any of the field value.
         Refer to the template documentation to learn special fields data structure.
@@ -111,6 +118,9 @@ defmodule Aurora.Uix.Field do
     type: :string,
     html_type: :text,
     renderer: nil,
+    index_renderer: nil,
+    edit_renderer: nil,
+    show_renderer: nil,
     resource: nil,
     name: "",
     label: "",
@@ -134,6 +144,9 @@ defmodule Aurora.Uix.Field do
           html_type: atom() | binary() | nil,
           html_id: binary(),
           renderer: function() | nil,
+          index_renderer: function() | nil,
+          edit_renderer: function() | nil,
+          show_renderer: function() | nil,
           data: any() | nil,
           resource: module() | nil,
           name: binary(),

--- a/lib/aurora_uix/guides/blog/post.ex
+++ b/lib/aurora_uix/guides/blog/post.ex
@@ -75,7 +75,6 @@ defmodule Aurora.Uix.Guides.Blog.Post do
     read :read do
       primary? true
       pagination required?: false, offset?: true
-      prepare build(load: :summary)
     end
   end
 

--- a/lib/aurora_uix/integration/ash/fields_parser.ex
+++ b/lib/aurora_uix/integration/ash/fields_parser.ex
@@ -503,6 +503,8 @@ defmodule Aurora.Uix.Integration.Ash.FieldsParser do
 
   # Extracts metadata for Ash field types
   @spec field_data(map(), map()) :: map()
+  defp field_data(_attrs, %{generated_type: _generated_type}), do: %{generated: true}
+
   defp field_data(
          _attrs,
          %{type: resource_type, constraints: constraints}

--- a/lib/aurora_uix/layout/blueprint.ex
+++ b/lib/aurora_uix/layout/blueprint.ex
@@ -149,7 +149,7 @@ defmodule Aurora.Uix.Layout.Blueprint do
       auix_resource_metadata(:product, context: Inventory, schema: Product)
 
       auix_create_ui do
-        index_columns :product, [:reference, name: [renderer: &upcase_text/1]]
+        index_columns :product, [:reference, name: [index_renderer: &upcase_text/1]]
         edit_layout :product do
           inline [id: [hidden: true], reference: [readonly: true, length: 30], description: [length: 255]]
         end
@@ -323,10 +323,14 @@ defmodule Aurora.Uix.Layout.Blueprint do
     Takes precedence over any order_by set in `auix_resource_metadata`.
     See `Aurora.Uix.Layout.ResourceMetadata.auix_resource_metadata/3` for details.
   - `:where` (keyword()) - Where clauses to use for filtering the items to show.
-  - Field-level options can be provided as keyword lists for each field (e.g., `[name: [renderer: &custom_renderer/1]]`).
+  - Field-level options can be provided as keyword lists for each field (e.g., `[name: [index_renderer: &custom_renderer/1]]`).
 
   ## Field-level Options
   Besides the metadata options, there are some field types that can accept specific options for changing the way they are rendered.
+
+  - `:index_renderer` (`function/1`) - Custom rendering function for this column in the index table.
+    Receives the field assigns (`@entity`, `@field`, `@auix`) and must return a
+    `Phoenix.LiveView.Rendered.t()`. Index columns do **not** fall back to `:renderer`.
 
   ### Fields representing **one-to-many** association.
   - `:order_by` (atom() | list() | keyword()) - `Order by` used for displaying the related items.
@@ -367,6 +371,9 @@ defmodule Aurora.Uix.Layout.Blueprint do
   index_columns :product, [:name, :price],
     page_title: "Products List",
     page_subtitle: "All available products"
+
+  # Custom per-column rendering in the index table
+  index_columns :product, [:reference, name: [index_renderer: &MyApp.Views.upcase_name/1]]
 
   # Add a custom row action and remove the default delete action
   defmodule MyApp.Actions do

--- a/lib/aurora_uix/layout/create_ui.ex
+++ b/lib/aurora_uix/layout/create_ui.ex
@@ -55,8 +55,15 @@ defmodule Aurora.Uix.Layout.CreateUI do
       |> Enum.reject(&is_nil/1)
       |> Map.new()
 
+    resource_preloads = extract_resource_preloads(configurations)
+
+    preload_configurations =
+      configurations
+      |> Enum.reduce([], &[build_resource_preload_option(&1, resource_preloads) | &2])
+      |> Map.new()
+
     modules =
-      build_layouts(configurations, module)
+      build_layouts(preload_configurations, module)
 
     quote do
       unquote(modules)
@@ -70,7 +77,13 @@ defmodule Aurora.Uix.Layout.CreateUI do
       @doc false
       @spec auix_configurations() :: map()
       def auix_configurations do
-        unquote(Macro.escape(configurations))
+        unquote(Macro.escape(preload_configurations))
+      end
+
+      @doc false
+      @spec auix_preloads() :: map()
+      def auix_preloads do
+        unquote(Macro.escape(resource_preloads))
       end
     end
   end
@@ -157,15 +170,12 @@ defmodule Aurora.Uix.Layout.CreateUI do
 
   # Builds the layouts for the given resource configurations.
   @spec build_layouts(map(), module()) :: [Macro.t()]
-  defp build_layouts(configurations, caller) do
-    resource_preloads = extract_resource_preloads(configurations)
-
-    configurations
-    |> Enum.reduce([], &[build_resource_preload_option(&1, resource_preloads) | &2])
-    |> Map.new()
-    |> then(fn configurations ->
-      Enum.reduce(configurations, [], &[build_resource_layouts(&1, configurations, caller) | &2])
-    end)
+  defp build_layouts(preload_configurations, caller) do
+    Enum.reduce(
+      preload_configurations,
+      [],
+      &[build_resource_layouts(&1, preload_configurations, caller) | &2]
+    )
   end
 
   # Builds the configuration for a single resource.
@@ -313,18 +323,47 @@ defmodule Aurora.Uix.Layout.CreateUI do
   # Extracts resource preloads from configurations.
   @spec extract_resource_preloads(map()) :: map()
   defp extract_resource_preloads(configurations) do
-    configurations
-    |> Enum.map(fn {resource_name,
-                    %{resource_config: %{fields: fields}, layout_trees: layout_trees}} ->
-      layout_trees
-      |> Enum.filter(&(elem(&1, 0) in [:index, :form, :show]))
-      |> Enum.map(&elem(&1, 1))
-      |> extract_resource_fields(fields)
-      |> Enum.map(&{&1.name, &1.resource})
-      |> Enum.uniq()
-      |> then(&{resource_name, &1})
+    fields_by_resource =
+      Enum.map(configurations, fn {resource_name,
+                                   %{
+                                     resource_config: %{fields: fields},
+                                     layout_trees: layout_trees
+                                   }} ->
+        preload_fields =
+          layout_trees
+          |> Enum.filter(&(elem(&1, 0) in [:index, :form, :show]))
+          |> Enum.map(&elem(&1, 1))
+          |> extract_resource_fields(fields)
+          |> Enum.uniq_by(& &1.name)
+
+        {resource_name, preload_fields}
+      end)
+
+    associations =
+      fields_by_resource
+      |> Enum.map(fn {resource_name, resource_fields} ->
+        resource_fields
+        |> Enum.reject(&Map.get(&1, :generated, false))
+        |> Enum.map(&{&1.name, &1.resource})
+        |> then(&{resource_name, &1})
+      end)
+      |> expand_associations()
+
+    generated =
+      fields_by_resource
+      |> Enum.map(fn {resource_name, resource_fields} ->
+        resource_fields
+        |> Enum.filter(&Map.get(&1, :generated, false))
+        |> Enum.map(& &1.name)
+        |> then(&{resource_name, &1})
+      end)
+      |> Map.new()
+
+    Map.merge(associations, generated, fn _resource_name,
+                                          association_preloads,
+                                          generated_fields ->
+      generated_fields ++ association_preloads
     end)
-    |> expand_associations()
   end
 
   # Extracts resource fields from a list of resources.
@@ -343,12 +382,17 @@ defmodule Aurora.Uix.Layout.CreateUI do
     resource
     |> maybe_add_association_info(fields)
     |> then(&extract_resource_fields(inner_elements, fields, [&1]))
-    |> Enum.filter(
-      &(&1.tag == :field and &1.type in [:one_to_many_association, :many_to_one_association])
-    )
+    |> Enum.filter(&filter_preloads/1)
     |> Enum.reduce(result, &[&1 | &2])
     |> then(&extract_resource_fields(resources, fields, &1))
   end
+
+  @spec filter_preloads(map()) :: boolean()
+  defp filter_preloads(%{tag: :field, type: type})
+       when type in [:one_to_many_association, :many_to_one_association], do: true
+
+  defp filter_preloads(%{tag: :field, generated: true}), do: true
+  defp filter_preloads(_field), do: false
 
   # Adds association information to a field if it's an association.
   @spec maybe_add_association_info(map(), map()) :: map()
@@ -364,8 +408,15 @@ defmodule Aurora.Uix.Layout.CreateUI do
 
   defp maybe_add_association_info(%{tag: :field, name: name} = field, fields) do
     fields
-    |> Map.get(name, %{type: nil, resource: nil})
-    |> then(&Map.merge(field, %{type: &1.type, resource: &1.resource, inner_elements: []}))
+    |> Map.get(name, %{type: nil, resource: nil, data: %{}})
+    |> then(
+      &Map.merge(field, %{
+        type: &1.type,
+        resource: &1.resource,
+        generated: match?(%{generated: true}, Map.get(&1, :data)),
+        inner_elements: []
+      })
+    )
   end
 
   defp maybe_add_association_info(field, _fields), do: Map.put(field, :inner_elements, [])

--- a/lib/aurora_uix/layout/create_ui.ex
+++ b/lib/aurora_uix/layout/create_ui.ex
@@ -129,6 +129,23 @@ defmodule Aurora.Uix.Layout.CreateUI do
   end
 
   ## PRIVATE
+
+  # Folds each field TreePath's per-field :opts into :config so render-time get_field/3
+  # (which merges only :config) applies layout-DSL field options for index/form/show alike.
+  @spec fold_field_opts_into_config(map()) :: map()
+  defp fold_field_opts_into_config(%{tag: :field, inner_elements: inner} = element) do
+    opts = Map.get(element, :opts, [])
+
+    element
+    |> Map.update(:config, [], &Keyword.merge(opts, &1))
+    |> Map.put(:inner_elements, Enum.map(inner, &fold_field_opts_into_config/1))
+  end
+
+  defp fold_field_opts_into_config(%{inner_elements: inner} = element),
+    do: Map.put(element, :inner_elements, Enum.map(inner, &fold_field_opts_into_config/1))
+
+  defp fold_field_opts_into_config(element), do: element
+
   # Merges layout paths by their name and tag, combining inner elements and options.
   @spec merge_layout_trees(tuple()) :: list()
   defp merge_layout_trees({_, paths}) do
@@ -215,6 +232,7 @@ defmodule Aurora.Uix.Layout.CreateUI do
           |> Map.get(tag)
           |> Blueprint.build_default_layout_paths(resource_config, opts, tag)
           |> Blueprint.parse_sections(tag)
+          |> fold_field_opts_into_config()
           |> then(&{tag, &1})
         end)
         |> Map.new()

--- a/lib/aurora_uix/layout/helpers.ex
+++ b/lib/aurora_uix/layout/helpers.ex
@@ -355,5 +355,13 @@ defmodule Aurora.Uix.Layout.Helpers do
     |> then(&{option_key, &1})
   end
 
+  defp process_field_tag_option({option_key, {:&, _, _} = function_capture}, env) do
+    env
+    |> Code.env_for_eval()
+    |> then(&Code.eval_quoted_with_env(function_capture, [], &1))
+    |> elem(0)
+    |> then(&{option_key, &1})
+  end
+
   defp process_field_tag_option(option, _env), do: option
 end

--- a/lib/aurora_uix/layout/resource_metadata.ex
+++ b/lib/aurora_uix/layout/resource_metadata.ex
@@ -245,7 +245,14 @@ defmodule Aurora.Uix.Layout.ResourceMetadata do
   - `:readonly` (`boolean()`) - Marks the field as read-only.
   - `:hidden` (`boolean()`) - Hides the field.
   - `:filterable?` (`boolean()`) - If true, allows the field to participate in UI filtering.
-  - `:renderer` (`function()`) - Custom rendering function/component.
+  - `:renderer` (`function()`) - Custom rendering function/component, used for the form (edit) and
+    show layouts unless a more specific `:edit_renderer`/`:show_renderer` is provided.
+  - `:index_renderer` (`function()`) - Custom rendering function/component used only for the index
+    layout. Index columns do not fall back to `:renderer`.
+  - `:edit_renderer` (`function()`) - Custom rendering function/component used only for the form
+    (edit) layout. Falls back to `:renderer` when not set.
+  - `:show_renderer` (`function()`) - Custom rendering function/component used only for the show
+    layout. Falls back to `:renderer` when not set.
   - `:required` (`boolean()`) - Marks the field as required.
   - `:disabled` (`boolean()`) - If true, the field should not participate in form interaction.
   - `:omitted` (`boolean()`) - If true, the field will be entirely excluded from the UI and configuration.

--- a/lib/aurora_uix/templates/basic/helpers.ex
+++ b/lib/aurora_uix/templates/basic/helpers.ex
@@ -876,13 +876,19 @@ defmodule Aurora.Uix.Templates.Basic.Helpers do
     parsed_opts
     |> Map.get(:preload)
     |> List.flatten()
-    |> Enum.map(&elem(&1, 0))
+    |> Enum.map(&preload_entry_name/1)
     |> Enum.uniq()
     |> Enum.map(&get_field(%{name: &1}, parsed_opts.configurations, parsed_opts.resource_name))
     |> Enum.filter(&(&1.type in [:many_to_one_association, :one_to_many_association]))
     |> Enum.map(&{&1.type, &1.key})
     |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
   end
+
+  # Extracts the field name from a preload entry, which may be a bare atom
+  # (e.g. a generated field) or an `{name, related}` association tuple.
+  @spec preload_entry_name(atom() | tuple()) :: atom()
+  defp preload_entry_name(name) when is_atom(name), do: name
+  defp preload_entry_name({name, _related}), do: name
 
   @doc """
   Flattens a nested structure of elements into a list of paths.

--- a/lib/aurora_uix/templates/basic/renderers/field_renderer.ex
+++ b/lib/aurora_uix/templates/basic/renderers/field_renderer.ex
@@ -37,24 +37,32 @@ defmodule Aurora.Uix.Templates.Basic.Renderers.FieldRenderer do
   """
   @spec render(map()) :: Phoenix.LiveView.Rendered.t()
   def render(%{auix: auix} = assigns) do
-    field =
-      get_field_info(auix)
+    field = get_field_info(auix)
 
-    assigns = assign(assigns, :field, field)
-
-    case field do
-      %{omitted: true} ->
-        empty_render(assigns)
-
-      %{renderer: custom_renderer} when is_function(custom_renderer, 1) ->
-        custom_renderer.(assigns)
-
-      _field ->
-        default_render(assigns)
-    end
+    assigns
+    |> assign(:field, field)
+    |> do_render()
   end
 
   # PRIVATE
+
+  @spec do_render(map()) :: Phoenix.LiveView.Rendered.t()
+  defp do_render(%{field: %{omitted: true}} = assigns), do: empty_render(assigns)
+
+  defp do_render(
+         %{field: %{show_renderer: custom_renderer}, auix: %{layout_type: :show}} = assigns
+       )
+       when is_function(custom_renderer, 1), do: custom_renderer.(assigns)
+
+  defp do_render(
+         %{field: %{edit_renderer: custom_renderer}, auix: %{layout_type: :form}} = assigns
+       )
+       when is_function(custom_renderer, 1), do: custom_renderer.(assigns)
+
+  defp do_render(%{field: %{renderer: custom_renderer}} = assigns)
+       when is_function(custom_renderer, 1), do: custom_renderer.(assigns)
+
+  defp do_render(assigns), do: default_render(assigns)
 
   # Returns field info for rendering, handling tuple and atom names
   @spec get_field_info(map()) :: map()

--- a/lib/aurora_uix/templates/basic/renderers/index_renderer.ex
+++ b/lib/aurora_uix/templates/basic/renderers/index_renderer.ex
@@ -194,6 +194,9 @@ defmodule Aurora.Uix.Templates.Basic.Renderers.IndexRenderer do
     """
   end
 
+  defp field_value(%{field: %{index_renderer: custom_renderer}} = assigns)
+       when is_function(custom_renderer, 1), do: custom_renderer.(assigns)
+
   defp field_value(assigns) do
     ~H"""
     {Map.get(@entity, @field.key)}

--- a/lib/aurora_uix_web/guides/ash_overview.ex
+++ b/lib/aurora_uix_web/guides/ash_overview.ex
@@ -52,7 +52,7 @@ defmodule Aurora.UixWeb.Guides.AshOverview do
     index_columns(:post, [:title, :author, :status])
 
     show_layout :post do
-      stacked([:status, :title, :author, :comment])
+      stacked([:status, :title, :author, :comment, :summary])
     end
 
     edit_layout :post do
@@ -65,6 +65,7 @@ defmodule Aurora.UixWeb.Guides.AshOverview do
           stacked([:status, :published_at])
         end
 
+        inline([:summary])
         inline([:tags])
       end
     end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Aurora.Uix.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/wadvanced/aurora_uix"
-  @version "0.1.5-rc.2"
+  @version "0.1.5-rc.3"
 
   def project do
     [

--- a/test/cases_live/ash_embeds_test.exs
+++ b/test/cases_live/ash_embeds_test.exs
@@ -24,7 +24,7 @@ defmodule Aurora.UixWeb.Test.AshEmbedsTest do
 
   auix_create_ui do
     edit_layout :author do
-      stacked([:name, :email, :posts])
+      stacked([:name, :email, :posts, :posts_count])
     end
 
     edit_layout :post,
@@ -33,6 +33,7 @@ defmodule Aurora.UixWeb.Test.AshEmbedsTest do
         inline([:status])
         stacked([:title, :content])
         stacked([:comment, :tags])
+        stacked([:summary])
       end
     end
   end
@@ -181,5 +182,33 @@ defmodule Aurora.UixWeb.Test.AshEmbedsTest do
     assert post_count_resource.type == :integer
     assert post_count_resource.html_type == :number
     assert post_count_resource.label == "Posts Count"
+  end
+
+  test "Generated fields referenced in layouts are added to auix_preloads" do
+    preloads = AshEmbedsTest.auix_preloads()
+
+    assert :summary in preloads.post
+    assert :posts_count in preloads.author
+  end
+
+  test "Show renders a calculation value without a manual read-action load", %{conn: conn} do
+    delete_all_blog_data()
+
+    author =
+      1
+      |> create_sample_authors()
+      |> List.first()
+
+    post =
+      1
+      |> create_sample_posts(%{author_id: author.id, comment: %{}})
+      |> List.first()
+
+    {:ok, view, _html} = live(conn, "/ash-embeds-posts/#{post.id}/show")
+
+    assert has_element?(
+             view,
+             "div.auix-show-container input[name='summary'][value='#{post.title} is #{post.status}'][disabled]"
+           )
   end
 end

--- a/test/cases_live/custom_field_renderers_test.exs
+++ b/test/cases_live/custom_field_renderers_test.exs
@@ -1,0 +1,226 @@
+defmodule Aurora.UixWeb.Test.CustomFieldRenderersTest do
+  use Aurora.UixWeb.Test.UICase, :phoenix_case
+  use Aurora.UixWeb.Test.WebCase, :aurora_uix_for_test
+
+  import Phoenix.Component, only: [sigil_H: 2]
+
+  alias Aurora.Uix.Guides.Inventory
+  alias Aurora.Uix.Guides.Inventory.Product
+
+  auix_resource_metadata :product, context: Inventory, schema: Product do
+    field(:reference, renderer: &__MODULE__.renderer/1)
+
+    field(:name,
+      index_renderer: &__MODULE__.index_marker/1,
+      edit_renderer: &__MODULE__.edit_marker/1,
+      show_renderer: &__MODULE__.show_marker/1
+    )
+  end
+
+  # When you define a link in a test, add a line to test/support/app_web/routes.ex
+  # See section `Including cases_live tests in the test server` in the README.md file.
+  auix_create_ui()
+
+  @doc false
+  @spec renderer(map()) :: Phoenix.LiveView.Rendered.t()
+  def renderer(%{auix: %{layout_type: :form}} = assigns) do
+    ~H"""
+    <span class="auix-generic-renderer">GENERIC:{@auix.form[@field.key].value}</span>
+    """
+  end
+
+  def renderer(assigns) do
+    ~H"""
+    <span class="auix-generic-renderer">GENERIC:{Map.get(@auix.entity || %{}, @field.key)}</span>
+    """
+  end
+
+  @doc false
+  @spec index_marker(map()) :: Phoenix.LiveView.Rendered.t()
+  def index_marker(assigns) do
+    ~H"""
+    <span class="auix-index-marker">IDX:{Map.get(@entity, @field.key)}</span>
+    """
+  end
+
+  @doc false
+  @spec edit_marker(map()) :: Phoenix.LiveView.Rendered.t()
+  def edit_marker(assigns) do
+    ~H"""
+    <span class="auix-edit-marker">EDIT:{@auix.form[@field.key].value}</span>
+    """
+  end
+
+  @doc false
+  @spec show_marker(map()) :: Phoenix.LiveView.Rendered.t()
+  def show_marker(assigns) do
+    ~H"""
+    <span class="auix-show-marker">SHOW:{Map.get(@auix.entity || %{}, @field.key)}</span>
+    """
+  end
+
+  describe "index layout" do
+    test "uses index_renderer for the field it's set on, default rendering for others", %{
+      conn: conn
+    } do
+      delete_all_inventory_data()
+      create_sample_products(1, :test)
+
+      {:ok, view, _html} = live(conn, "/custom-field-renderers-products")
+
+      assert has_element?(view, "span.auix-index-marker", "IDX:Item test-1")
+      assert has_element?(view, "td", "item_test-1")
+      refute has_element?(view, "span.auix-generic-renderer")
+    end
+  end
+
+  describe "show layout" do
+    test "uses show_renderer for the field it's set on", %{conn: conn} do
+      delete_all_inventory_data()
+
+      product_id =
+        1
+        |> create_sample_products(:test)
+        |> get_in([Access.key!("id_test-1"), Access.key!(:id)])
+
+      {:ok, view, _html} = live(conn, "/custom-field-renderers-products/#{product_id}/show")
+
+      assert has_element?(view, "span.auix-show-marker", "SHOW:Item test-1")
+    end
+
+    test "falls back to the generic renderer when show_renderer is not set but renderer is", %{
+      conn: conn
+    } do
+      delete_all_inventory_data()
+
+      product_id =
+        1
+        |> create_sample_products(:test)
+        |> get_in([Access.key!("id_test-1"), Access.key!(:id)])
+
+      {:ok, view, _html} = live(conn, "/custom-field-renderers-products/#{product_id}/show")
+
+      assert has_element?(view, "span.auix-generic-renderer", "GENERIC:item_test-1")
+    end
+  end
+
+  describe "form (edit) layout" do
+    test "uses edit_renderer for the field it's set on", %{conn: conn} do
+      delete_all_inventory_data()
+
+      product_id =
+        1
+        |> create_sample_products(:test)
+        |> get_in([Access.key!("id_test-1"), Access.key!(:id)])
+
+      {:ok, view, _html} = live(conn, "/custom-field-renderers-products/#{product_id}/edit")
+
+      assert has_element?(view, "span.auix-edit-marker", "EDIT:Item test-1")
+    end
+
+    test "falls back to the generic renderer when edit_renderer is not set but renderer is", %{
+      conn: conn
+    } do
+      delete_all_inventory_data()
+
+      product_id =
+        1
+        |> create_sample_products(:test)
+        |> get_in([Access.key!("id_test-1"), Access.key!(:id)])
+
+      {:ok, view, _html} = live(conn, "/custom-field-renderers-products/#{product_id}/edit")
+
+      assert has_element?(view, "span.auix-generic-renderer", "GENERIC:item_test-1")
+    end
+  end
+
+  describe "regression: default rendering unaffected" do
+    test "fields without any custom renderer still render with default input/display", %{
+      conn: conn
+    } do
+      delete_all_inventory_data()
+
+      product_id =
+        1
+        |> create_sample_products(:test)
+        |> get_in([Access.key!("id_test-1"), Access.key!(:id)])
+
+      {:ok, view, _html} = live(conn, "/custom-field-renderers-products/#{product_id}/edit")
+
+      assert has_element?(view, "input[name='product[quantity_initial]']")
+    end
+  end
+end
+
+defmodule Aurora.UixWeb.Test.CustomFieldRenderersIndexColumnsTest do
+  use Aurora.UixWeb.Test.UICase, :phoenix_case
+  use Aurora.UixWeb.Test.WebCase, :aurora_uix_for_test
+
+  import Phoenix.Component, only: [sigil_H: 2]
+
+  alias Aurora.Uix.Guides.Inventory
+  alias Aurora.Uix.Guides.Inventory.Product
+
+  auix_resource_metadata(:product, context: Inventory, schema: Product)
+
+  # When you define a link in a test, add a line to test/support/app_web/routes.ex
+  # See section `Including cases_live tests in the test server` in the README.md file.
+  auix_create_ui do
+    index_columns(:product,
+      reference: [label: "ZZZ_CustomRef"],
+      name: [index_renderer: &__MODULE__.index_marker/1]
+    )
+  end
+
+  @doc false
+  @spec index_marker(map()) :: Phoenix.LiveView.Rendered.t()
+  def index_marker(assigns) do
+    ~H"""
+    <span class="auix-index-cols-marker">COL:{Map.get(@entity, @field.key)}</span>
+    """
+  end
+
+  test "index_columns keyword-list threads index_renderer and other opts into the column", %{
+    conn: conn
+  } do
+    delete_all_inventory_data()
+    create_sample_products(1, :test)
+
+    {:ok, view, html} = live(conn, "/custom-field-renderers-index-columns-products")
+
+    # index_renderer applied to the :name column
+    assert has_element?(view, "span.auix-index-cols-marker", "COL:Item test-1")
+    assert has_element?(view, "td", "item_test-1")
+    # a plain per-column option (:label) threads through the same path
+    assert html =~ "ZZZ_CustomRef"
+  end
+end
+
+defmodule Aurora.UixWeb.Test.InlineFieldOptsTest do
+  use Aurora.UixWeb.Test.UICase, :phoenix_case
+  use Aurora.UixWeb.Test.WebCase, :aurora_uix_for_test
+
+  alias Aurora.Uix.Guides.Inventory
+  alias Aurora.Uix.Guides.Inventory.Product
+
+  auix_resource_metadata(:product, context: Inventory, schema: Product)
+
+  auix_create_ui do
+    edit_layout :product do
+      inline(reference: [readonly: true], name: [])
+    end
+  end
+
+  test "per-field opts set inside an inline layout list take effect", %{conn: conn} do
+    delete_all_inventory_data()
+
+    product_id =
+      1
+      |> create_sample_products(:test)
+      |> get_in([Access.key!("id_test-1"), Access.key!(:id)])
+
+    {:ok, view, _html} = live(conn, "/inline-field-opts-products/#{product_id}/edit")
+
+    assert has_element?(view, "input[name='product[reference]'][readonly]")
+  end
+end

--- a/test/support/app_web/routes.ex
+++ b/test/support/app_web/routes.ex
@@ -34,6 +34,21 @@ defmodule Aurora.UixWeb.Test.Routes do
         )
 
         RoutesHelper.register_crud(
+          CustomFieldRenderersTest.Product,
+          "custom-field-renderers-products"
+        )
+
+        RoutesHelper.register_crud(
+          CustomFieldRenderersIndexColumnsTest.Product,
+          "custom-field-renderers-index-columns-products"
+        )
+
+        RoutesHelper.register_crud(
+          InlineFieldOptsTest.Product,
+          "inline-field-opts-products"
+        )
+
+        RoutesHelper.register_crud(
           GroupUILayoutTest.Product,
           "group-ui-layout-products"
         )


### PR DESCRIPTION
> 🤖 **GENERATED-DESCRIPTION:START** — auto-generated; edit above or below, never inside.

## Summary
- Adds three per-layout custom renderer options to `Aurora.Uix.Field` — `index_renderer`, `edit_renderer`, `show_renderer` — alongside the existing generic `renderer`. Index columns previously had no custom-renderer support; form (edit) and show now prefer their layout-specific renderer and fall back to the generic `renderer`, preserving prior behavior (`lib/aurora_uix/field.ex`, `field_renderer.ex`, `index_renderer.ex`).
- Fixes a pre-existing bug where per-field options set inside layout DSL field lists (`index_columns`/`inline`/`stacked` keyword lists) were silently dropped at render time: `create_field_tag` stored them under the TreePath's `:opts` key while `get_field/3` only merged `:config`, and function captures were left as unevaluated quoted AST instead of real functions. `create_ui.ex` now folds `:opts` into `:config` for every field, and `layout/helpers.ex` evaluates `&fun/arity` captures at compile time, so layout-DSL field options work uniformly across index, form, and show.
- Auto-loads Ash calculations and aggregates referenced in generated layouts, so computed/aggregated fields no longer need manual preload configuration (`lib/aurora_uix/layout/create_ui.ex`, `lib/aurora_uix/integration/ash/fields_parser.ex`).
- Adds `test/cases_live/custom_field_renderers_test.exs` covering renderer dispatch/fallback for show, edit, and index (via both the `field(...)` block form and the `index_columns` keyword-list DSL), plus a default-rendering regression check.
- Documents the new renderer options across the Resource Metadata and Layouts guides, with cross-links from the customization hub, and updates the CHANGELOG.

Closes #301

> 🤖 **GENERATED-DESCRIPTION:END**
