### PR TITLE
fix: index update unsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ Requires:
     because only UUID/`:binary_id` foreign keys had a clause. Added a fallback so default Phoenix schemas (integer ids) render the picker.
 - **Many-to-one select on Ash resources** — building dropdown options raised `Protocol.Enumerable not implemented for Aurora.Ctx.Pagination`. `get_select_options/1` 
     now normalises the paginated Ash result (and the plain Ecto list) to a list of entries before mapping.
+- **Update of index list upon creating/adding records** - After a record is created or updated, the index of records was not properly updated. Added missing tests to ensure no regressions.
 
 ### Documentation
 

--- a/lib/aurora_uix/templates/basic/handlers/index_impl.ex
+++ b/lib/aurora_uix/templates/basic/handlers/index_impl.ex
@@ -592,21 +592,22 @@ defmodule Aurora.Uix.Templates.Basic.Handlers.IndexImpl do
   @doc """
   Handles info messages for the LiveView.
 
-  Processes save notifications by inserting entities into the stream, ignores other messages.
+  Processes save notifications by refreshing the current page from the data source, ignores
+  other messages.
 
   ## Parameters
   - `event_info` (term()) - Info message, typically `{component, {:saved, entity}}`.
   - `socket` (Socket.t()) - LiveView socket.
 
   ## Returns
-  `{:noreply, Socket.t()}` - Updated socket with entity inserted into stream or unchanged.
+  `{:noreply, Socket.t()}` - Updated socket with the current page refreshed or unchanged.
   """
   @spec auix_handle_info(term(), Socket.t()) :: {:noreply, Socket.t()}
   def auix_handle_info(
-        {_component, {:saved, entity}},
-        %{assigns: %{auix: auix, streams: _streams}} = socket
+        {_component, {:saved, _entity}},
+        %{assigns: %{auix: _auix, streams: _streams}} = socket
       ) do
-    {:noreply, stream_insert(socket, auix.source_key, entity)}
+    {:noreply, refresh_current_page(socket)}
   end
 
   def auix_handle_info(_input, socket) do

--- a/test/cases_live/ash_default_layout_test.exs
+++ b/test/cases_live/ash_default_layout_test.exs
@@ -247,4 +247,33 @@ defmodule Aurora.UixWeb.Test.AshDefaultLayoutTest do
     assert updated_html =~ updated_name
     assert updated_html =~ updated_bio
   end
+
+  test "Test CREATE new author updates the index list without remounting", %{conn: conn} do
+    delete_all_blog_data()
+    {:ok, view, _html} = live(conn, "/ash-default-layout-authors/new")
+
+    unique_name = "Author-#{System.system_time(:nanosecond)}"
+    unique_email = "author-#{System.system_time(:nanosecond)}@test.com"
+    unique_bio = "Test bio #{System.system_time(:nanosecond)}"
+
+    view
+    |> form("#auix-author-form",
+      author: %{
+        name: unique_name,
+        email: unique_email,
+        bio: unique_bio
+      }
+    )
+    |> render_submit()
+
+    # The parent index only refreshes once it processes the `:saved` handle_info message,
+    # which is queued after the "save" event's own reply. A follow-up render/1 call queues
+    # behind it in the same process mailbox, so it deterministically observes the refresh.
+    refreshed_html = render(view)
+    assert refreshed_html =~ unique_name
+    assert refreshed_html =~ unique_email
+    refute refreshed_html =~ "No items to show"
+
+    assert has_element?(view, "td", unique_name)
+  end
 end

--- a/test/cases_live/create_ui_layout_test.exs
+++ b/test/cases_live/create_ui_layout_test.exs
@@ -95,6 +95,32 @@ defmodule Aurora.UixWeb.Test.CreateUILayoutTest do
     assert new_html =~ "test-first"
   end
 
+  test "Test CREATE new updates the index list without remounting", %{conn: conn} do
+    delete_all_inventory_data()
+    {:ok, view, _html} = live(conn, "/create-ui-layout-products/new")
+
+    unique_reference = "test-#{System.system_time(:nanosecond)}"
+
+    view
+    |> form("#auix-product-form",
+      product: %{
+        reference: unique_reference,
+        name: "This is the second test",
+        quantity_initial: 11
+      }
+    )
+    |> render_submit()
+
+    # The parent index only refreshes once it processes the `:saved` handle_info message,
+    # which is queued after the "save" event's own reply. A follow-up render/1 call queues
+    # behind it in the same process mailbox, so it deterministically observes the refresh.
+    refreshed = render(view)
+    assert refreshed =~ unique_reference
+    refute refreshed =~ "No items to show"
+
+    assert has_element?(view, "td", unique_reference)
+  end
+
   test "Test index layout", %{conn: conn} do
     delete_all_inventory_data()
     create_sample_products(5, :test)


### PR DESCRIPTION
> 🤖 **GENERATED-DESCRIPTION:START** — auto-generated; edit above or below, never inside.

## Summary
- Fixes a bug where returning to the index after creating a record via the "New" form (which navigates back with `push_patch`, keeping the same LiveView process alive) left the list looking unchanged — the "No items to show" empty state stayed visible even after the first record was added.
- Root cause: the index's `:saved` `handle_info` clause in `Aurora.Uix.Templates.Basic.Handlers.IndexImpl.auix_handle_info/2` inserted the raw saved entity directly via `stream_insert/3`, bypassing `refresh_current_page/1` — the same helper already used by delete, filter-submit, and bulk-selection to recompute pagination, sort order, and the `empty_list?` assign. Because `stream_insert` never touched `empty_list?`, the empty-state overlay stayed stuck as soon as the list had previously been empty.
- Fix: the `:saved` clause now calls `refresh_current_page/1`, so create and edit both go through the same DB re-fetch, preload, and enrichment pipeline as every other index mutation path.
- Adds regression tests in `create_ui_layout_test.exs` (Ecto/`aurora_ctx` backend) and `ash_default_layout_test.exs` (Ash backend) that submit the "New" form and assert on the *same* LiveView (no remount), verifying the empty-state message clears and the new row appears — the prior tests only asserted via a fresh `live/2` mount, which bypassed the buggy code path entirely.

> 🤖 **GENERATED-DESCRIPTION:END**
