### PR TITLE
feat: action-label layout options and arity-0 name/title support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,16 @@ Requires:
     subtype's `one_of` (or the subtype's own enum module), instead of falling through to a text
     input.
 
+- **New action-label layout options and arity-0 name/title functions**
+  - `:new_action_label` (`:index`), `:save_action_label` (`:form`), and `:edit_action_label` /
+    `:back_action_label` (`:show`) — configurable labels for the corresponding action buttons,
+    alongside the existing title/subtitle options.
+  - A resource's `:name`/`:title` metadata (set via `auix_resource_metadata/3`) can now also be a
+    captured 0-arity function returning a binary, resolved via the new
+    `Aurora.Uix.Layout.Options.parse_value/1`, wherever these values are interpolated into title,
+    subtitle and action-label defaults. This is separate from the existing arity-1,
+    `assigns`-receiving functions already supported by per-layout title/subtitle options.
+
 ### Changed
 
 - **`Templates.Basic.Helpers.many_to_many_candidate_ids/2` renamed to `select_candidate_ids/2`**

--- a/guides/core/layouts.md
+++ b/guides/core/layouts.md
@@ -303,6 +303,7 @@ index_columns :product, [:reference, :name, :price],
 - `:page_subtitle` — Subtitle (default: empty)
 - `:pagination_items_per_page` — Rows per page (default: 40)
 - `:pagination_disabled?` — Disable pagination (default: `false`)
+- `:new_action_label` — Label for the "new" action button (default: `"New {name}"`)
 - `:order_by` — Initial sort order; uses `Aurora.Ctx.QueryBuilder` syntax
 - `:where` — Query filter; uses `Aurora.Ctx.QueryBuilder` syntax
 
@@ -326,6 +327,7 @@ end
 - `:edit_subtitle` — Subtitle for edit form (default: `"Use this form to manage <strong>{title}</strong> records in your database"`)
 - `:new_title` — Title for create form (default: `"New {name}"`)
 - `:new_subtitle` — Subtitle for create form (default: `"Creates a new <strong>{name}</strong> record in your database"`)
+- `:save_action_label` — Label for the save action button (default: `"Save {name}"`)
 
 #### Show Layout Options
 
@@ -343,6 +345,8 @@ end
 **Options:**
 - `:page_title` — Main title (default: `"{name}"` - the resource name)
 - `:page_subtitle` — Subtitle (default: `"Details"`)
+- `:edit_action_label` — Label for the edit action button (default: `"Edit {name}"`)
+- `:back_action_label` — Label for the back action (default: `"Back to {title}"`)
 
 ### Dynamic Titles & Subtitles
 
@@ -370,6 +374,13 @@ end
 ```
 
 The function receives `assigns` and should return rendered HTML (using sigil `~H`).
+
+> **Note:** This is separate from the resource's own `name`/`title` metadata (set via
+> `auix_resource_metadata/3`), which many of the defaults above interpolate (e.g. `"New
+> {name}"`, `"Back to {title}"`). Those accept a plain `binary()` or a captured **0-arity**
+> function returning a `binary()` — a different signature from the arity-1, `assigns`-receiving
+> functions documented here. See [Resource Metadata → Display Name and
+> Title](resource_metadata.md#display-name-and-title).
 
 ### Field-Level Options
 

--- a/guides/core/resource_metadata.md
+++ b/guides/core/resource_metadata.md
@@ -132,6 +132,33 @@ For Ash Framework resources:
 
 When using Ash resources, you can also use `:schema` as an alias for `:ash_resource` 
 
+### Display Name and Title
+
+Both backends accept two optional presentation options, independent of the resource's
+identifier (the macro's first positional `name` argument):
+
+- `:name` (`binary()` or 0-arity `function()`) - Optional. The resource's display name, used
+  to build default titles and action labels (e.g. `"New {name}"`, `"Edit {name}"`). Defaults
+  to the capitalized schema module name (e.g. `MyApp.Product` → `"Product"`).
+- `:title` (`binary()` or 0-arity `function()`) - Optional. The resource's display title, used
+  in other title/subtitle defaults (e.g. `"Listing {title}"`, `"Back to {title}"`). Defaults
+  to the capitalized schema source/table name (e.g. `"products"` → `"Products"`).
+
+In addition to a plain `binary()`, both options accept a captured 0-arity function returning a
+`binary()`, evaluated wherever the default is built:
+
+```elixir
+auix_resource_metadata :product,
+  schema: MyApp.Inventory.Product,
+  context: MyApp.Inventory,
+  name: "Product",
+  title: &MyApp.Inventory.Product.display_title/0
+```
+
+This is a different mechanism from the arity-1, `assigns`-receiving functions accepted by
+per-layout title/subtitle options (`:page_title`, `:edit_title`, and similar) — see
+[Layout System → Dynamic Titles & Subtitles](layouts.md#dynamic-titles--subtitles) for that.
+
 Let's see examples for both approaches:
 
 ### Example Schema

--- a/lib/aurora_uix/layout/options.ex
+++ b/lib/aurora_uix/layout/options.ex
@@ -22,6 +22,18 @@ defmodule Aurora.Uix.Layout.Options do
     end
   end
   ```
+
+  ## Function-valued options
+
+  Two distinct function mechanisms are supported, and they are not interchangeable:
+
+  - **Layout options** (e.g. `:page_title`, `:edit_title`, `:new_action_label`) accept an
+    arity-1 function that receives `assigns` and returns a `Phoenix.LiveView.Rendered.t()`.
+    See `get_option/3`.
+  - **Resource `name`/`title` metadata** (set via `auix_resource_metadata/3`, consumed as
+    `assigns.auix.name` / `assigns.auix.title`) additionally accepts a **0-arity** function
+    returning a `binary()`, resolved through `parse_value/1`. This is what every title,
+    subtitle and action-label default interpolates when building its display string.
   """
 
   import Phoenix.Component, only: [sigil_H: 2]
@@ -258,6 +270,49 @@ defmodule Aurora.Uix.Layout.Options do
 
     ~H"{@auix_option_value}"
   end
+
+  @doc """
+  Normalizes a value into a display binary.
+
+  Used to resolve resource `name`/`title` metadata (and similar values) into the binary
+  ultimately interpolated into title, subtitle and action-label defaults. Unlike the
+  arity-1 functions accepted by `get_option/3` (which receive `assigns`), this accepts a
+  **0-arity** function, letting `name`/`title` be computed independently of the render
+  context.
+
+  ## Parameters
+
+  - `value` (`nil | binary() | function()`) - The raw value to normalize:
+    - `nil` resolves to `""`.
+    - A `binary()` is returned as-is.
+    - A 0-arity function is called and its result returned.
+    - Any other value is converted with `to_string/1`.
+
+  ## Returns
+
+  - `binary()` - The resolved display value.
+
+  ## Examples
+
+  ```elixir
+  iex> Aurora.Uix.Layout.Options.parse_value(nil)
+  ""
+
+  iex> Aurora.Uix.Layout.Options.parse_value("Product")
+  "Product"
+
+  iex> Aurora.Uix.Layout.Options.parse_value(fn -> "Product" end)
+  "Product"
+  ```
+  """
+  @spec parse_value(nil | binary() | function()) :: binary()
+  def parse_value(nil), do: ""
+
+  def parse_value(name) when is_binary(name), do: name
+
+  def parse_value(name_fun) when is_function(name_fun, 0), do: name_fun.()
+
+  def parse_value(name), do: to_string(name)
 
   ## PRIVATE
 

--- a/lib/aurora_uix/layout/options/form.ex
+++ b/lib/aurora_uix/layout/options/form.ex
@@ -23,6 +23,11 @@ defmodule Aurora.Uix.Layout.Options.Form do
     - Accepts a `binary()` or a function of arity 1 that receives assigns and returns a Phoenix.LiveView.Rendered.
     - Default: `"Creates a new <strong>{name}</strong> record in your database"`, where `{name}` is the resource name.
 
+  * `:save_action_label` - The text to show for the save action button.
+    - Accepts a `binary()` or a 0-arity function returning a `binary()` (see
+      `Aurora.Uix.Layout.Options.parse_value/1`).
+    - Default: `"Save {name}"`, where `{name}` is the resource name.
+
   * `:record_navigator` - Controls the display position of the record navigation bar.
     - Accepts an `atom()` (`:top`, `:bottom`) or a list of atoms `[:top, :bottom]`.
     - Default: `[:top, :bottom]` - Shows the record navigation bar at both top and bottom.
@@ -38,26 +43,29 @@ defmodule Aurora.Uix.Layout.Options.Form do
   # Returns default values for supported options, otherwise delegates error.
   @spec get_default(map(), atom()) :: {:ok, term()} | {:not_found, atom()}
   defp get_default(%{auix: %{name: name}} = assigns, :edit_title),
-    do: {:ok, LayoutOptions.render_binary(assigns, "Edit #{name}")}
+    do: {:ok, LayoutOptions.render_binary(assigns, "Edit #{LayoutOptions.parse_value(name)}")}
 
   defp get_default(%{auix: %{title: title}} = assigns, :edit_subtitle),
     do:
       {:ok,
        LayoutOptions.render_binary(
          assigns,
-         "Use this form to manage <strong>#{title}</strong> records in your database"
+         "Use this form to manage <strong>#{LayoutOptions.parse_value(title)}</strong> records in your database"
        )}
 
   defp get_default(%{auix: %{name: name}} = assigns, :new_title),
-    do: {:ok, LayoutOptions.render_binary(assigns, "New #{name}")}
+    do: {:ok, LayoutOptions.render_binary(assigns, "New #{LayoutOptions.parse_value(name)}")}
 
   defp get_default(%{auix: %{name: name}} = assigns, :new_subtitle),
     do:
       {:ok,
        LayoutOptions.render_binary(
          assigns,
-         "Creates a new <strong>#{name}</strong> record in your database"
+         "Creates a new <strong>#{LayoutOptions.parse_value(name)}</strong> record in your database"
        )}
+
+  defp get_default(%{auix: %{name: name}}, :save_action_label),
+    do: {:ok, "Save #{LayoutOptions.parse_value(name)}"}
 
   defp get_default(_assigns, :record_navigator),
     do: {:ok, [:top, :bottom]}

--- a/lib/aurora_uix/layout/options/index.ex
+++ b/lib/aurora_uix/layout/options/index.ex
@@ -26,6 +26,10 @@ defmodule Aurora.Uix.Layout.Options.Index do
   * `:page_subtitle` - The subtitle for the index list.
     - Accepts a `binary()` or a function of arity 1 that receives assigns and returns a Phoenix.LiveView.Rendered.
     - Default: `""`.
+  * `:new_action_label` - The label used in the "new" action button.
+    - Accepts a `binary()` or a 0-arity function returning a `binary()` (see
+      `Aurora.Uix.Layout.Options.parse_value/1`).
+    - Default: `"New {name}"`, where `{name}` is the resource name.
   * `:get_streams` - Function for extracting row data from assigns
   * `:row_id` - Function for extracting row identifiers
   """
@@ -118,7 +122,7 @@ defmodule Aurora.Uix.Layout.Options.Index do
     do: {:ok, false}
 
   defp get_default(%{auix: %{layout_tree: %{tag: :index}, title: title}} = assigns, :page_title),
-    do: {:ok, LayoutOptions.render_binary(assigns, "Listing #{title}")}
+    do: {:ok, LayoutOptions.render_binary(assigns, "Listing #{LayoutOptions.parse_value(title)}")}
 
   defp get_default(%{auix: %{layout_tree: %{tag: :index}}}, :page_subtitle),
     do: {:ok, ""}
@@ -137,6 +141,9 @@ defmodule Aurora.Uix.Layout.Options.Index do
 
   defp get_default(%{auix: %{layout_tree: %{tag: :index}}}, :pagination_items_per_page),
     do: {:ok, @default_items_per_page}
+
+  defp get_default(%{auix: %{layout_tree: %{tag: :index}, name: name}}, :new_action_label),
+    do: {:ok, "New #{LayoutOptions.parse_value(name)}"}
 
   defp get_default(%{auix: %{layout_tree: %{tag: :index}}}, :alternate_streams_suffixes),
     do: {:ok, ["mobile"]}

--- a/lib/aurora_uix/layout/options/show.ex
+++ b/lib/aurora_uix/layout/options/show.ex
@@ -15,6 +15,16 @@ defmodule Aurora.Uix.Layout.Options.Show do
     - Accepts a `binary()` or a function of arity 1 that receives assigns and expected to return a Phoenix.LiveView.Rendered.
     - Default: `"Detail"`
 
+  * `:edit_action_label` - The edit text that will appear in the action button.
+    - Accepts a `binary()` or a 0-arity function returning a `binary()` (see
+      `Aurora.Uix.Layout.Options.parse_value/1`).
+    - Default: `"Edit {name}"`, where `{name}` is the resource name.
+
+  * `:back_action_label` - The text for the back action.
+    - Accepts a `binary()` or a 0-arity function returning a `binary()` (see
+      `Aurora.Uix.Layout.Options.parse_value/1`).
+    - Default: `"Back to {title}"`, where `{title}` is the resource title.
+
   * `:record_navigator` - Controls the display position of the record navigation bar.
     - Accepts an `atom()` (`:top`, `:bottom`) or a list of atoms `[:top, :bottom]`.
     - Default: `[:top, :bottom]` - Shows the record navigation bar at both top and bottom.
@@ -28,10 +38,22 @@ defmodule Aurora.Uix.Layout.Options.Show do
   # Returns default values for supported options, otherwise delegates error.
   @spec get_default(map(), atom()) :: {:ok, term()} | {:not_found, atom()}
   defp get_default(%{auix: %{layout_tree: %{tag: :show}, name: name}} = assigns, :page_title),
-    do: {:ok, LayoutOptions.render_binary(assigns, "#{name}")}
+    do: {:ok, LayoutOptions.render_binary(assigns, "#{LayoutOptions.parse_value(name)}")}
 
   defp get_default(%{auix: %{layout_tree: %{tag: :show}}} = assigns, :page_subtitle),
     do: {:ok, LayoutOptions.render_binary(assigns, "Details")}
+
+  defp get_default(
+         %{auix: %{layout_tree: %{tag: :show}, name: name}},
+         :edit_action_label
+       ),
+       do: {:ok, "Edit #{LayoutOptions.parse_value(name)}"}
+
+  defp get_default(
+         %{auix: %{layout_tree: %{tag: :show}, title: title}},
+         :back_action_label
+       ),
+       do: {:ok, "Back to #{LayoutOptions.parse_value(title)}"}
 
   defp get_default(_assigns, :record_navigator),
     do: {:ok, [:top, :bottom]}

--- a/lib/aurora_uix/templates/basic/actions/form.ex
+++ b/lib/aurora_uix/templates/basic/actions/form.ex
@@ -59,7 +59,7 @@ defmodule Aurora.Uix.Templates.Basic.Actions.Form do
   @spec save_action(map()) :: Rendered.t()
   def save_action(assigns) do
     ~H"""
-    <.button phx-disable-with={dt("Saving...")} name={"auix-save-#{@auix.module}"}>{dt("Save")} {@auix.name}</.button>
+    <.button phx-disable-with={dt("Saving...")} name={"auix-save-#{@auix.module}"}>{dt(@auix.layout_options.save_action_label)}</.button>
     """
   end
 

--- a/lib/aurora_uix/templates/basic/actions/index.ex
+++ b/lib/aurora_uix/templates/basic/actions/index.ex
@@ -324,7 +324,7 @@ defmodule Aurora.Uix.Templates.Basic.Actions.Index do
   def new_header_action(assigns) do
     ~H"""
     <.auix_link patch={"#{@auix[:index_new_link]}"} name={"auix-new-#{@auix.module}"} role="button">
-      <.button>{dt("New")} {@auix.name}</.button>
+      <.button>{dt(@auix.layout_options.new_action_label)}</.button>
     </.auix_link>
     """
   end

--- a/lib/aurora_uix/templates/basic/actions/show_component.ex
+++ b/lib/aurora_uix/templates/basic/actions/show_component.ex
@@ -61,7 +61,7 @@ defmodule Aurora.Uix.Templates.Basic.Actions.ShowComponent do
   def edit_header_action(assigns) do
     ~H"""
       <.auix_link patch={"/#{@auix.uri_path}/#{BasicHelpers.primary_key_value(@auix.entity, @auix.primary_key)}/show-edit"} name={"auix-edit-#{@auix.module}"}>
-        <.button>{dt("Edit")} {@auix.name}</.button>
+        <.button>{dt(@auix.layout_options.edit_action_label)}</.button>
       </.auix_link>
     """
   end
@@ -80,7 +80,7 @@ defmodule Aurora.Uix.Templates.Basic.Actions.ShowComponent do
   def back_footer_action(assigns) do
     ~H"""
       <div name="auix-show-navigate-back">
-        <.auix_back>Back to {@auix.title}</.auix_back>
+        <.auix_back>{dt(@auix.layout_options.back_action_label)}</.auix_back>
       </div>
     """
   end

--- a/lib/aurora_uix/templates/basic/renderers/form_renderer.ex
+++ b/lib/aurora_uix/templates/basic/renderers/form_renderer.ex
@@ -38,8 +38,8 @@ defmodule Aurora.Uix.Templates.Basic.Renderers.FormRenderer do
     <div>
       <.record_navigator_bar :if={@action in [:edit, :show_edit] and record_navigator?(@auix, :top)} pagination={@auix.pagination} item_index={@auix.item_index} />
       <.header>
-        {if @action in [:edit, :show_edit], do: @auix.layout_options.edit_title, else: @auix.layout_options.new_title}
-        <:subtitle>{if @action in [:edit, :show_edit], do: @auix.layout_options.edit_subtitle, else: @auix.layout_options.new_subtitle}</:subtitle>
+        {if @action in [:edit, :show_edit], do: dt(@auix.layout_options.edit_title), else: dt(@auix.layout_options.new_title)}
+        <:subtitle>{if @action in [:edit, :show_edit], do: @auix.layout_options.edit_subtitle, else: dt(@auix.layout_options.new_subtitle)}</:subtitle>
         <:actions>
           <div name="auix-form-header-actions">
             <%= for %{function_component: action} <- @auix.form_header_actions do %>

--- a/lib/aurora_uix/templates/basic/renderers/index_renderer.ex
+++ b/lib/aurora_uix/templates/basic/renderers/index_renderer.ex
@@ -55,10 +55,10 @@ defmodule Aurora.Uix.Templates.Basic.Renderers.IndexRenderer do
     <div class="auix-index-container">
       <.header>
         <div id={"auix-table-#{@auix.uri_path_id}-index-title"}>
-          {@auix.layout_options.page_title}
+          {dt(@auix.layout_options.page_title)}
         </div>
         <:subtitle>
-          {@auix.layout_options.page_subtitle}
+          {dt(@auix.layout_options.page_subtitle)}
         </:subtitle>
       </.header>
 

--- a/lib/aurora_uix/templates/basic/renderers/show_component_renderer.ex
+++ b/lib/aurora_uix/templates/basic/renderers/show_component_renderer.ex
@@ -39,8 +39,8 @@ defmodule Aurora.Uix.Templates.Basic.Renderers.ShowComponentRenderer do
       <div class="auix-show-container">
         <.record_navigator_bar :if={record_navigator?(@auix, :top)} pagination={@auix.pagination} item_index={@auix.item_index} />
         <.header>
-          {@auix.layout_options.page_title}
-          <:subtitle :if={@auix.layout_options.page_subtitle != nil}>{@auix.layout_options.page_subtitle}</:subtitle>
+          {dt(@auix.layout_options.page_title)}
+          <:subtitle :if={@auix.layout_options.page_subtitle != nil}>{dt(@auix.layout_options.page_subtitle)}</:subtitle>
           <:actions>
             <div name="auix-show-header-actions">
               <%= for %{function_component: action} <- @auix.show_header_actions do %>

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Aurora.Uix.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/wadvanced/aurora_uix"
-  @version "0.1.6-rc.1"
+  @version "0.1.6-rc.2"
 
   def project do
     [


### PR DESCRIPTION
> 🤖 **GENERATED-DESCRIPTION:START** — auto-generated; edit above or below, never inside.

## Summary
- Adds four new layout options — `:new_action_label` (`:index`), `:save_action_label` (`:form`), and `:edit_action_label` / `:back_action_label` (`:show`) — so the corresponding action button labels are configurable, alongside the existing title/subtitle options.
- Lets resource `:name`/`:title` metadata (set via `auix_resource_metadata/3`) be a captured 0-arity function returning a binary, in addition to a plain binary, resolved through the new `Aurora.Uix.Layout.Options.parse_value/1`. This is wired into every title/subtitle/action-label default in `Options.Index`, `Options.Form` and `Options.Show`, and the corresponding action/renderer templates now route these labels through localization (`dt/1`).
- Documents both additions: `@doc` for `parse_value/1`, updated moduledoc bullets for the four new options in `options/{index,form,show}.ex`, a new "Display Name and Title" section in `guides/core/resource_metadata.md`, updated option tables and a clarifying note in `guides/core/layouts.md`, and a `CHANGELOG.md` entry under `[0.1.6]`.

> 🤖 **GENERATED-DESCRIPTION:END**
