### PR TITLE
fix: theming variable split, flat group containers, and form subtitle rendering

### DIFF
--- a/.doctor.exs
+++ b/.doctor.exs
@@ -4,7 +4,7 @@
     Aurora.Uix.ComponentsResolverHelper,
     Aurora.Uix.Guides.Accounts.User.Email,
     Aurora.Uix.Guides.Accounts.User.Profile,
-    Aurora.Uix.Gettext,
+    Aurora.Uix.GettextResolver,
     Aurora.Uix.Layout.CreateUI,
     Aurora.Uix.Layout.Options,
     Aurora.Uix.Layout.ResourceMetadata,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ Requires:
     as any other string option.
   - The index subtitle `<:subtitle>` slot is now only rendered `:if` `page_subtitle` is set, instead
     of always being present with an empty-string default that rendered a blank line.
+  - The `:edit_subtitle` and `:new_subtitle` form defaults previously embedded `<strong>…</strong>`
+    markup around the resource name, relying on the removed `render_binary/2` raw-HTML wrapping to
+    render it unescaped. Since these are plain strings now, the markup is dropped in favor of a
+    plain `'…'` quoting (`"Creates a new 'Product' record in your database"`); the now-dead
+    `Aurora.Uix.Layout.Options.render_binary/2` helper is removed. Also fixes `edit_subtitle` never
+    being routed through `dt/1`/Gettext, unlike its `new_subtitle`/`edit_title`/`new_title` siblings.
 
 - **Multi-value atom and enum attributes not detected as multiple selects**
   - An Ash `{:array, :atom}` with an `items: [one_of: ...]` constraint, and its Ecto counterpart

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ Requires:
 
 ### Fixes
 
+- **Title/subtitle layout options no longer run through dynamic-template rendering**
+  - `edit_title`, `edit_subtitle`, `new_title`, `new_subtitle`, index `page_title`, and show
+    `page_title`/`page_subtitle` defaults are plain interpolated strings, but
+    `LayoutOptions.get_option/3` special-cased every binary title/subtitle option through
+    `LayoutOptions.render_binary/2` (dynamic template evaluation) regardless. That special-case,
+    and the `@title_options` list backing it, are removed — these options are returned as-is, same
+    as any other string option.
+  - The index subtitle `<:subtitle>` slot is now only rendered `:if` `page_subtitle` is set, instead
+    of always being present with an empty-string default that rendered a blank line.
+
 - **Multi-value atom and enum attributes not detected as multiple selects**
   - An Ash `{:array, :atom}` with an `items: [one_of: ...]` constraint, and its Ecto counterpart
     `{:array, Ecto.Enum}`, described a set of options the user picks from, but neither parser
@@ -33,6 +43,13 @@ Requires:
     enum can be exercised end-to-end in tests.
 
 ### Added
+
+- **Separate font-size variables for group titles and index empty states**
+  - `--auix-font-size-title` drove the page title, group headings and the index empty-state message
+    at once, so a host that wanted a larger page title had to override `.auix-group-title` by class
+    to stop group headings growing with it. `--auix-font-size-group-title` and
+    `--auix-font-size-empty-state` now cover those two roles and default to
+    `var(--auix-font-size-title)`, so nothing changes until one of them is set.
 
 - **Multi-value selects render as a checkbox group**
   - A multi-value select no longer renders as a `<select multiple>`, which needs an undiscoverable
@@ -76,6 +93,30 @@ Requires:
     `assigns`-receiving functions already supported by per-layout title/subtitle options.
 
 ### Changed
+
+- **`Aurora.Uix.Gettext` renamed to `Aurora.Uix.GettextResolver`**
+  - The old name shadowed the `Gettext` library module, so code generated inside the macro's own
+    `__using__/1` block could not call `Gettext.*` directly without the ambiguity. Every internal
+    `use Aurora.Uix.Gettext` call site is updated; host apps using this macro must update the same.
+  - The macro's injected `backend/0` helper is now private (`gettext_backend/0`) — it is only ever
+    called from code generated in the same module, and being public caused it to be pulled in by
+    `import Aurora.Uix.Templates.Basic.Helpers`, conflicting with an identically-named local
+    function there.
+
+- **Group containers are now flat by default** (visual change)
+  - `.auix-group-container` painted a full card — background, border, radius — but a group is
+    always rendered inside a container that already paints one (`.auix-show-content`,
+    `.auix-form-container` or `.auix-sections-content`), so any `group`-based layout produced
+    card-inside-card. `--auix-color-group-container-bg` and `--auix-color-group-container-border`
+    now default to `transparent`; padding and border width are unchanged, so spacing and vertical
+    rhythm stay identical.
+  - To keep the previous look, restore the two variables in your own stylesheet:
+    ```css
+    :root {
+      --auix-color-group-container-bg: var(--auix-color-bg-light);
+      --auix-color-group-container-border: var(--auix-color-border-primary);
+    }
+    ```
 
 - **`Templates.Basic.Helpers.many_to_many_candidate_ids/2` renamed to `select_candidate_ids/2`**
   - It now resolves the candidate set of any multi-value select, not only a many-to-many membership.

--- a/guides/core/layouts.md
+++ b/guides/core/layouts.md
@@ -324,9 +324,9 @@ end
 
 **Options:**
 - `:edit_title` — Title for edit form (default: `"Edit {name}"`)
-- `:edit_subtitle` — Subtitle for edit form (default: `"Use this form to manage <strong>{title}</strong> records in your database"`)
+- `:edit_subtitle` — Subtitle for edit form (default: `"Use this form to manage '{title}' records in your database"`)
 - `:new_title` — Title for create form (default: `"New {name}"`)
-- `:new_subtitle` — Subtitle for create form (default: `"Creates a new <strong>{name}</strong> record in your database"`)
+- `:new_subtitle` — Subtitle for create form (default: `"Creates a new '{name}' record in your database"`)
 - `:save_action_label` — Label for the save action button (default: `"Save {name}"`)
 
 #### Show Layout Options

--- a/guides/customization/styling.md
+++ b/guides/customization/styling.md
@@ -212,7 +212,9 @@ rules-level overrides win over it.
 | `--auix-font-sans` | `ui-sans-serif, system-ui, sans-serif, …` | Sans-serif font stack |
 | `--auix-font-mono` | `ui-monospace, SFMono-Regular, Menlo, …` | Monospace font stack |
 | `--auix-font-family-default` | `var(--auix-font-sans)` | Default font family for all components |
-| `--auix-font-size-title` | `1.125rem` | Section and page titles |
+| `--auix-font-size-title` | `1.125rem` | Page title (`.auix-header-title`) |
+| `--auix-font-size-group-title` | `var(--auix-font-size-title)` | Group headings (`.auix-group-title`) |
+| `--auix-font-size-empty-state` | `var(--auix-font-size-title)` | Index empty-state message (table and card) |
 | `--auix-font-size-subtitle` | `1rem` | Subtitles and secondary headings |
 | `--auix-font-size-caption` | `0.875rem` | Labels, inputs, table cells |
 | `--auix-font-size-small` | `0.750rem` | Badges and helper text |
@@ -346,8 +348,8 @@ rules-level overrides win over it.
 | `--auix-color-horizontal-divider` | `var(--auix-color-border-primary)` | Horizontal rule color |
 | `--auix-color-flash-close-text` | `var(--auix-color-text-secondary)` | Flash close-button icon |
 | `--auix-color-form-container-bg` | `var(--auix-color-bg-default)` | Form container background |
-| `--auix-color-group-container-bg` | `var(--auix-color-bg-light)` | Group/card container background |
-| `--auix-color-group-container-border` | `var(--auix-color-border-primary)` | Group/card container border |
+| `--auix-color-group-container-bg` | `transparent` | Group container background (flat by default) |
+| `--auix-color-group-container-border` | `transparent` | Group container border (flat by default) |
 | `--auix-color-show-content-bg` | `var(--auix-color-bg-default)` | Show-view content background |
 | `--auix-color-header-title-text` | `var(--auix-color-text-label)` | Page/section header title |
 | `--auix-color-header-subtitle-text` | `var(--auix-color-text-secondary)` | Page/section header subtitle |
@@ -396,6 +398,8 @@ Common visual adjustments and the minimal set of variables to override:
 | Brand primary color | `--auix-color-button-bg`, `--auix-color-button-text`, `--auix-color-bg-default--reverted` |
 | Dark backgrounds | `--auix-color-bg-default`, `--auix-color-bg-light`, `--auix-color-bg-hover` |
 | Tighter list rows | `--auix-gap-minimal`, `--auix-padding-minimal`, `--auix-margin-default` |
+| Larger page title only | `--auix-font-size-title` (group headings and empty states stay put) |
+| Card-style groups (pre-0.1.6 look) | `--auix-color-group-container-bg`, `--auix-color-group-container-border` |
 | Bolder labels | `--auix-font-weight-bold`, `--auix-color-text-label` |
 
 ## Rule: one color class per element

--- a/lib/aurora_uix/helpers/gettext_backend.ex
+++ b/lib/aurora_uix/helpers/gettext_backend.ex
@@ -34,13 +34,13 @@ defmodule Aurora.Uix.GettextBackend do
   ## Replacing this backend
 
   Pass a different module via the `:gettext_backend` application key or via the `:backend` option
-  on `use Aurora.Uix.Gettext`:
+  on `use Aurora.Uix.GettextResolver`:
 
   ```elixir
   config :aurora_uix, gettext_backend: MyApp.CustomGettextBackend
   ```
 
-  See `Aurora.Uix.Gettext` for the backend resolution order.
+  See `Aurora.Uix.GettextResolver` for the backend resolution order.
   """
   use Gettext.Backend, otp_app: :aurora_uix
 

--- a/lib/aurora_uix/helpers/gettext_resolver.ex
+++ b/lib/aurora_uix/helpers/gettext_resolver.ex
@@ -1,4 +1,4 @@
-defmodule Aurora.Uix.Gettext do
+defmodule Aurora.Uix.GettextResolver do
   @moduledoc """
   Injects Gettext functionality with configurable backend support.
 
@@ -17,16 +17,16 @@ defmodule Aurora.Uix.Gettext do
   ## Examples
   ```elixir
   defmodule MyApp.Gettext do
-    use Aurora.Uix.Gettext
+    use Aurora.Uix.GettextResolver
   end
 
   defmodule MyApp.Gettext do
-    use Aurora.Uix.Gettext, backend: MyCustomBackend
+    use Aurora.Uix.GettextResolver, backend: MyCustomBackend
   end
 
   # Usage in modules
   defmodule MyApp.Web do
-    use Aurora.Uix.Gettext
+    use Aurora.Uix.GettextResolver
   end
 
   # Then use standard Gettext functions
@@ -42,7 +42,7 @@ defmodule Aurora.Uix.Gettext do
 
   require Logger
 
-  @gettext_domain Application.compile_env(:aurora_uix, :gettext_domain, nil)
+  @gettext_domain Application.compile_env(:aurora_uix, :gettext_domain, "default")
 
   @doc false
   @spec __using__(keyword()) :: Macro.t()
@@ -52,14 +52,7 @@ defmodule Aurora.Uix.Gettext do
     backend_module =
       Application.get_env(:aurora_uix, :gettext_backend, default_backend)
 
-    gettext_domain = @gettext_domain
-
-    dt_implementation =
-      if gettext_domain do
-        domain_dt_implementation(gettext_domain)
-      else
-        default_dt_implementation()
-      end
+    dt_implementation = domain_dt_implementation(@gettext_domain)
 
     # For deprecated implementation
     gettext_module = Application.get_env(:aurora_uix, :gettext)
@@ -77,11 +70,11 @@ defmodule Aurora.Uix.Gettext do
 
     quote do
       unquote(implementation)
-      @gettext_domain unquote(gettext_domain)
+      @gettext_domain unquote(@gettext_domain)
       unquote(dt_implementation)
 
-      @doc false
-      def backend do
+      @spec gettext_backend() :: module()
+      defp gettext_backend do
         unquote(backend_module)
       end
     end
@@ -95,33 +88,12 @@ defmodule Aurora.Uix.Gettext do
 
         case msgid do
           binary when is_binary(binary) ->
-            quote do: dgettext(unquote(domain), unquote(binary))
+            quote do: Gettext.dgettext(gettext_backend(), unquote(domain), unquote(binary))
 
           _dynamic ->
             quote do
               if is_binary(unquote(msgid)) do
-                Gettext.dgettext(backend(), unquote(domain), unquote(msgid))
-              else
-                unquote(msgid)
-              end
-            end
-        end
-      end
-    end
-  end
-
-  @spec default_dt_implementation() :: Macro.t()
-  defp default_dt_implementation do
-    quote do
-      defmacrop dt(msgid) do
-        case msgid do
-          binary when is_binary(binary) ->
-            quote do: gettext(unquote(binary))
-
-          _dynamic ->
-            quote do
-              if is_binary(unquote(msgid)) do
-                Gettext.gettext(backend(), unquote(msgid))
+                Gettext.dgettext(gettext_backend(), unquote(domain), unquote(msgid))
               else
                 unquote(msgid)
               end

--- a/lib/aurora_uix/layout/options.ex
+++ b/lib/aurora_uix/layout/options.ex
@@ -52,15 +52,6 @@ defmodule Aurora.Uix.Layout.Options do
                               ShowOptions,
                               FormOptions
                             ]
-  @title_options Application.compile_env(:aurora_uix, :layout_title_options, []) ++
-                   [
-                     :edit_title,
-                     :edit_subtitle,
-                     :new_title,
-                     :new_subtitle,
-                     :page_title,
-                     :page_subtitle
-                   ]
 
   @doc """
   Retrieves the list of available options for the layout.
@@ -229,10 +220,6 @@ defmodule Aurora.Uix.Layout.Options do
   def get_option(assigns, value, _option)
       when is_function(value, 1),
       do: {:ok, value.(assigns)}
-
-  def get_option(assigns, value, option)
-      when is_binary(value) and option in @title_options,
-      do: {:ok, LayoutOptions.render_binary(assigns, value)}
 
   def get_option(_assigns, value, _option), do: {:ok, value}
 

--- a/lib/aurora_uix/layout/options.ex
+++ b/lib/aurora_uix/layout/options.ex
@@ -224,41 +224,6 @@ defmodule Aurora.Uix.Layout.Options do
   def get_option(_assigns, value, _option), do: {:ok, value}
 
   @doc """
-  Renders a given value as a binary within a HEEx template.
-
-  This helper function is used to safely render a value by embedding it into an assigns map
-  and then rendering it with a `~H` sigil. The value is first passed through `raw/1` to
-  prevent HTML escaping.
-
-  ## Parameters
-
-  - `assigns` (map()) - The assigns map for the template.
-  - `value` (term()) - The value to be rendered.
-
-  ## Returns
-
-  - `Phoenix.LiveView.Rendered.t()` - The rendered HEEx content containing the value.
-
-  ## Examples
-
-  ```elixir
-  iex> assigns = %{}
-  iex> rendered = Aurora.Uix.Layout.Options.render_binary(assigns, "Hello, World!")
-  iex> Phoenix.HTML.safe_to_string(rendered)
-  "Hello, World!"
-  ```
-  """
-  @spec render_binary(map(), term()) :: Phoenix.LiveView.Rendered.t()
-  def render_binary(assigns, value) do
-    assigns =
-      value
-      |> raw()
-      |> then(&Map.put(assigns, :auix_option_value, &1))
-
-    ~H"{@auix_option_value}"
-  end
-
-  @doc """
   Normalizes a value into a display binary.
 
   Used to resolve resource `name`/`title` metadata (and similar values) into the binary

--- a/lib/aurora_uix/layout/options/form.ex
+++ b/lib/aurora_uix/layout/options/form.ex
@@ -42,27 +42,21 @@ defmodule Aurora.Uix.Layout.Options.Form do
 
   # Returns default values for supported options, otherwise delegates error.
   @spec get_default(map(), atom()) :: {:ok, term()} | {:not_found, atom()}
-  defp get_default(%{auix: %{name: name}} = assigns, :edit_title),
-    do: {:ok, LayoutOptions.render_binary(assigns, "Edit #{LayoutOptions.parse_value(name)}")}
+  defp get_default(%{auix: %{name: name}}, :edit_title),
+    do: {:ok, "Edit #{LayoutOptions.parse_value(name)}"}
 
-  defp get_default(%{auix: %{title: title}} = assigns, :edit_subtitle),
+  defp get_default(%{auix: %{title: title}}, :edit_subtitle),
     do:
       {:ok,
-       LayoutOptions.render_binary(
-         assigns,
-         "Use this form to manage <strong>#{LayoutOptions.parse_value(title)}</strong> records in your database"
-       )}
+       "Use this form to manage <strong>#{LayoutOptions.parse_value(title)}</strong> records in your database"}
 
-  defp get_default(%{auix: %{name: name}} = assigns, :new_title),
-    do: {:ok, LayoutOptions.render_binary(assigns, "New #{LayoutOptions.parse_value(name)}")}
+  defp get_default(%{auix: %{name: name}}, :new_title),
+    do: {:ok, "New #{LayoutOptions.parse_value(name)}"}
 
-  defp get_default(%{auix: %{name: name}} = assigns, :new_subtitle),
+  defp get_default(%{auix: %{name: name}}, :new_subtitle),
     do:
       {:ok,
-       LayoutOptions.render_binary(
-         assigns,
-         "Creates a new <strong>#{LayoutOptions.parse_value(name)}</strong> record in your database"
-       )}
+       "Creates a new <strong>#{LayoutOptions.parse_value(name)}</strong> record in your database"}
 
   defp get_default(%{auix: %{name: name}}, :save_action_label),
     do: {:ok, "Save #{LayoutOptions.parse_value(name)}"}

--- a/lib/aurora_uix/layout/options/form.ex
+++ b/lib/aurora_uix/layout/options/form.ex
@@ -13,7 +13,7 @@ defmodule Aurora.Uix.Layout.Options.Form do
 
   * `:edit_subtitle` - The subtitle for the edit form.
     - Accepts a `binary()` or a function of arity 1 that receives assigns and returns a Phoenix.LiveView.Rendered.
-    - Default: `"Use this form to manage <strong>{title}</strong> records in your database"`, where `{title}` is the resource title.
+    - Default: `"Use this form to manage '{title}' records in your database"`, where `{title}` is the resource title.
 
   * `:new_title` - The title for the new resource form.
     - Accepts a `binary()` or a function of arity 1 that receives assigns and returns a Phoenix.LiveView.Rendered.
@@ -21,7 +21,7 @@ defmodule Aurora.Uix.Layout.Options.Form do
 
   * `:new_subtitle` - The subtitle for the new resource form.
     - Accepts a `binary()` or a function of arity 1 that receives assigns and returns a Phoenix.LiveView.Rendered.
-    - Default: `"Creates a new <strong>{name}</strong> record in your database"`, where `{name}` is the resource name.
+    - Default: `"Creates a new '{name}' record in your database"`, where `{name}` is the resource name.
 
   * `:save_action_label` - The text to show for the save action button.
     - Accepts a `binary()` or a 0-arity function returning a `binary()` (see
@@ -48,15 +48,13 @@ defmodule Aurora.Uix.Layout.Options.Form do
   defp get_default(%{auix: %{title: title}}, :edit_subtitle),
     do:
       {:ok,
-       "Use this form to manage <strong>#{LayoutOptions.parse_value(title)}</strong> records in your database"}
+       "Use this form to manage '#{LayoutOptions.parse_value(title)}' records in your database"}
 
   defp get_default(%{auix: %{name: name}}, :new_title),
     do: {:ok, "New #{LayoutOptions.parse_value(name)}"}
 
   defp get_default(%{auix: %{name: name}}, :new_subtitle),
-    do:
-      {:ok,
-       "Creates a new <strong>#{LayoutOptions.parse_value(name)}</strong> record in your database"}
+    do: {:ok, "Creates a new '#{LayoutOptions.parse_value(name)}' record in your database"}
 
   defp get_default(%{auix: %{name: name}}, :save_action_label),
     do: {:ok, "Save #{LayoutOptions.parse_value(name)}"}

--- a/lib/aurora_uix/layout/options/index.ex
+++ b/lib/aurora_uix/layout/options/index.ex
@@ -121,8 +121,8 @@ defmodule Aurora.Uix.Layout.Options.Index do
   defp get_default(%{auix: %{layout_tree: %{tag: :index}}}, :pagination_disabled?),
     do: {:ok, false}
 
-  defp get_default(%{auix: %{layout_tree: %{tag: :index}, title: title}} = assigns, :page_title),
-    do: {:ok, LayoutOptions.render_binary(assigns, "Listing #{LayoutOptions.parse_value(title)}")}
+  defp get_default(%{auix: %{layout_tree: %{tag: :index}, title: title}}, :page_title),
+    do: {:ok, "Listing #{LayoutOptions.parse_value(title)}"}
 
   defp get_default(%{auix: %{layout_tree: %{tag: :index}}}, :page_subtitle),
     do: {:ok, ""}

--- a/lib/aurora_uix/layout/options/show.ex
+++ b/lib/aurora_uix/layout/options/show.ex
@@ -37,11 +37,11 @@ defmodule Aurora.Uix.Layout.Options.Show do
 
   # Returns default values for supported options, otherwise delegates error.
   @spec get_default(map(), atom()) :: {:ok, term()} | {:not_found, atom()}
-  defp get_default(%{auix: %{layout_tree: %{tag: :show}, name: name}} = assigns, :page_title),
-    do: {:ok, LayoutOptions.render_binary(assigns, "#{LayoutOptions.parse_value(name)}")}
+  defp get_default(%{auix: %{layout_tree: %{tag: :show}, name: name}}, :page_title),
+    do: {:ok, "#{LayoutOptions.parse_value(name)}"}
 
-  defp get_default(%{auix: %{layout_tree: %{tag: :show}}} = assigns, :page_subtitle),
-    do: {:ok, LayoutOptions.render_binary(assigns, "Details")}
+  defp get_default(%{auix: %{layout_tree: %{tag: :show}}}, :page_subtitle),
+    do: {:ok, "Details"}
 
   defp get_default(
          %{auix: %{layout_tree: %{tag: :show}, name: name}},

--- a/lib/aurora_uix/renderer.ex
+++ b/lib/aurora_uix/renderer.ex
@@ -96,7 +96,7 @@ defmodule Aurora.Uix.Renderer do
       @behaviour Aurora.Uix.Renderer
 
       use Aurora.Uix.CoreComponentsImporter
-      use Aurora.Uix.Gettext
+      use Aurora.Uix.GettextResolver
 
       import Aurora.Uix.Renderer, only: [display_value: 1, form_field: 1]
     end

--- a/lib/aurora_uix/templates/basic/actions/embeds_many.ex
+++ b/lib/aurora_uix/templates/basic/actions/embeds_many.ex
@@ -19,7 +19,7 @@ defmodule Aurora.Uix.Templates.Basic.Actions.EmbedsMany do
   """
 
   use Aurora.Uix.CoreComponentsImporter
-  use Aurora.Uix.Gettext
+  use Aurora.Uix.GettextResolver
 
   import Phoenix.Component, only: [sigil_H: 2, live_component: 1]
 

--- a/lib/aurora_uix/templates/basic/actions/form.ex
+++ b/lib/aurora_uix/templates/basic/actions/form.ex
@@ -19,7 +19,7 @@ defmodule Aurora.Uix.Templates.Basic.Actions.Form do
   """
 
   use Aurora.Uix.CoreComponentsImporter
-  use Aurora.Uix.Gettext
+  use Aurora.Uix.GettextResolver
 
   alias Aurora.Uix.Action
   alias Aurora.Uix.Templates.Basic.Actions

--- a/lib/aurora_uix/templates/basic/actions/index.ex
+++ b/lib/aurora_uix/templates/basic/actions/index.ex
@@ -22,7 +22,7 @@ defmodule Aurora.Uix.Templates.Basic.Actions.Index do
   """
 
   use Aurora.Uix.CoreComponentsImporter
-  use Aurora.Uix.Gettext
+  use Aurora.Uix.GettextResolver
   use Phoenix.Component
 
   import Aurora.Uix.Templates.Basic.Components

--- a/lib/aurora_uix/templates/basic/actions/many_to_many.ex
+++ b/lib/aurora_uix/templates/basic/actions/many_to_many.ex
@@ -29,7 +29,7 @@ defmodule Aurora.Uix.Templates.Basic.Actions.ManyToMany do
   """
 
   use Aurora.Uix.CoreComponentsImporter
-  use Aurora.Uix.Gettext
+  use Aurora.Uix.GettextResolver
 
   import Phoenix.Component, only: [sigil_H: 2]
 

--- a/lib/aurora_uix/templates/basic/actions/multi_select.ex
+++ b/lib/aurora_uix/templates/basic/actions/multi_select.ex
@@ -32,7 +32,7 @@ defmodule Aurora.Uix.Templates.Basic.Actions.MultiSelect do
   """
 
   use Aurora.Uix.CoreComponentsImporter
-  use Aurora.Uix.Gettext
+  use Aurora.Uix.GettextResolver
 
   import Phoenix.Component, only: [sigil_H: 2]
 

--- a/lib/aurora_uix/templates/basic/actions/show_component.ex
+++ b/lib/aurora_uix/templates/basic/actions/show_component.ex
@@ -16,7 +16,7 @@ defmodule Aurora.Uix.Templates.Basic.Actions.ShowComponent do
   """
 
   use Aurora.Uix.CoreComponentsImporter
-  use Aurora.Uix.Gettext
+  use Aurora.Uix.GettextResolver
   import Aurora.Uix.Templates.Basic.RoutingComponents
 
   alias Aurora.Uix.Action

--- a/lib/aurora_uix/templates/basic/components/components.ex
+++ b/lib/aurora_uix/templates/basic/components/components.ex
@@ -30,7 +30,7 @@ defmodule Aurora.Uix.Templates.Basic.Components do
   """
   use Aurora.Uix.CoreComponentsImporter
   use Aurora.Uix.ComponentsResolver, :basic_components
-  use Aurora.Uix.Gettext
+  use Aurora.Uix.GettextResolver
   use Phoenix.Component
 
   alias Phoenix.LiveView.JS

--- a/lib/aurora_uix/templates/basic/components/confirm_button.ex
+++ b/lib/aurora_uix/templates/basic/components/confirm_button.ex
@@ -55,7 +55,7 @@ defmodule Aurora.Uix.Templates.Basic.ConfirmButton do
   """
 
   use Aurora.Uix.CoreComponentsImporter
-  use Aurora.Uix.Gettext
+  use Aurora.Uix.GettextResolver
   use Phoenix.LiveComponent
   alias Phoenix.LiveView.JS
 

--- a/lib/aurora_uix/templates/basic/components/core_components.ex
+++ b/lib/aurora_uix/templates/basic/components/core_components.ex
@@ -19,7 +19,7 @@ defmodule Aurora.Uix.Templates.Basic.CoreComponents do
   > which will import either this module or a custom one as configured in your application or template.
 
   """
-  use Aurora.Uix.Gettext
+  use Aurora.Uix.GettextResolver
   use Phoenix.Component
 
   use Aurora.Uix.ComponentsResolver, :core_components
@@ -744,9 +744,9 @@ defmodule Aurora.Uix.Templates.Basic.CoreComponents do
     # with our gettext backend as first argument. Translations are
     # available in the errors.po file (as we use the "errors" domain).
     if count = opts[:count] do
-      Gettext.dngettext(backend(), "errors", msg, msg, count, opts)
+      Gettext.dngettext(gettext_backend(), "errors", msg, msg, count, opts)
     else
-      Gettext.dgettext(backend(), "errors", msg, opts)
+      Gettext.dgettext(gettext_backend(), "errors", msg, opts)
     end
   end
 

--- a/lib/aurora_uix/templates/basic/components/embeds_many_component.ex
+++ b/lib/aurora_uix/templates/basic/components/embeds_many_component.ex
@@ -35,7 +35,7 @@ defmodule Aurora.Uix.Templates.Basic.EmbedsManyComponent do
   """
 
   use Aurora.Uix.CoreComponentsImporter
-  use Aurora.Uix.Gettext
+  use Aurora.Uix.GettextResolver
   use Phoenix.LiveComponent
 
   import Aurora.Uix.Integration.Crud

--- a/lib/aurora_uix/templates/basic/generators/form_generator.ex
+++ b/lib/aurora_uix/templates/basic/generators/form_generator.ex
@@ -83,7 +83,7 @@ defmodule Aurora.Uix.Templates.Basic.Generators.FormGenerator do
         @moduledoc false
 
         use unquote(parsed_opts.modules.web), :live_component
-        use Aurora.Uix.Gettext
+        use Aurora.Uix.GettextResolver
         alias Aurora.Uix.Templates.Basic.Helpers, as: BasicHelpers
 
         unquote(extract_function)

--- a/lib/aurora_uix/templates/basic/handlers/index_impl.ex
+++ b/lib/aurora_uix/templates/basic/handlers/index_impl.ex
@@ -21,7 +21,7 @@ defmodule Aurora.Uix.Templates.Basic.Handlers.IndexImpl do
   - Assumes certain structure in the `auix` assign (e.g., `modules.context`, `source_key`, etc.)
   - Requires resource modules to implement CRUD operations via Aurora.Uix.Integration.Crud
   """
-  use Aurora.Uix.Gettext
+  use Aurora.Uix.GettextResolver
 
   import Aurora.Uix.Integration.Crud
   import Aurora.Uix.Templates.Basic.Helpers

--- a/lib/aurora_uix/templates/basic/helpers.ex
+++ b/lib/aurora_uix/templates/basic/helpers.ex
@@ -26,7 +26,7 @@ defmodule Aurora.Uix.Templates.Basic.Helpers do
 
   use Phoenix.Component
   use Phoenix.LiveComponent
-  use Aurora.Uix.Gettext
+  use Aurora.Uix.GettextResolver
 
   import Aurora.Uix.Integration.Crud
   alias Aurora.Uix.Action

--- a/lib/aurora_uix/templates/basic/renderers/default_renderer.ex
+++ b/lib/aurora_uix/templates/basic/renderers/default_renderer.ex
@@ -18,7 +18,7 @@ defmodule Aurora.Uix.Templates.Basic.Renderers.DefaultRenderer do
   """
 
   use Aurora.Uix.CoreComponentsImporter
-  use Aurora.Uix.Gettext
+  use Aurora.Uix.GettextResolver
 
   import Aurora.Uix.Templates.Basic.Components
 

--- a/lib/aurora_uix/templates/basic/renderers/embeds_one_renderer.ex
+++ b/lib/aurora_uix/templates/basic/renderers/embeds_one_renderer.ex
@@ -14,7 +14,7 @@ defmodule Aurora.Uix.Templates.Basic.Renderers.EmbedsOneRenderer do
   - Layout must be available for the embedded resource.
   """
   use Aurora.Uix.CoreComponentsImporter
-  use Aurora.Uix.Gettext
+  use Aurora.Uix.GettextResolver
 
   alias Aurora.Uix.Templates.Basic.Helpers, as: BasicHelpers
   alias Aurora.Uix.Templates.Basic.Renderer

--- a/lib/aurora_uix/templates/basic/renderers/fields/many_to_many.ex
+++ b/lib/aurora_uix/templates/basic/renderers/fields/many_to_many.ex
@@ -64,7 +64,7 @@ defmodule Aurora.Uix.Templates.Basic.Renderers.ManyToMany do
   """
 
   use Aurora.Uix.CoreComponentsImporter
-  use Aurora.Uix.Gettext
+  use Aurora.Uix.GettextResolver
 
   import Aurora.Uix.Templates.Basic.Components
 

--- a/lib/aurora_uix/templates/basic/renderers/fields/multi_select.ex
+++ b/lib/aurora_uix/templates/basic/renderers/fields/multi_select.ex
@@ -44,7 +44,7 @@ defmodule Aurora.Uix.Templates.Basic.Renderers.MultiSelect do
   """
 
   use Aurora.Uix.CoreComponentsImporter
-  use Aurora.Uix.Gettext
+  use Aurora.Uix.GettextResolver
 
   import Aurora.Uix.Templates.Basic.Components
 

--- a/lib/aurora_uix/templates/basic/renderers/fields/one_to_many.ex
+++ b/lib/aurora_uix/templates/basic/renderers/fields/one_to_many.ex
@@ -13,7 +13,7 @@ defmodule Aurora.Uix.Templates.Basic.Renderers.OneToMany do
   """
 
   use Aurora.Uix.CoreComponentsImporter
-  use Aurora.Uix.Gettext
+  use Aurora.Uix.GettextResolver
   import Aurora.Uix.Templates.Basic.Components
   import Aurora.Uix.Integration.Crud
 

--- a/lib/aurora_uix/templates/basic/renderers/fields/one_to_one.ex
+++ b/lib/aurora_uix/templates/basic/renderers/fields/one_to_one.ex
@@ -38,7 +38,7 @@ defmodule Aurora.Uix.Templates.Basic.Renderers.OneToOne do
   """
 
   use Aurora.Uix.CoreComponentsImporter
-  use Aurora.Uix.Gettext
+  use Aurora.Uix.GettextResolver
 
   alias Aurora.Uix.Templates.Basic.Helpers, as: BasicHelpers
   alias Aurora.Uix.Templates.Basic.Renderer

--- a/lib/aurora_uix/templates/basic/renderers/fields/upload_renderer.ex
+++ b/lib/aurora_uix/templates/basic/renderers/fields/upload_renderer.ex
@@ -4,7 +4,7 @@ defmodule Aurora.Uix.Templates.Basic.Renderers.UploadRenderer do
   """
 
   use Aurora.Uix.CoreComponentsImporter
-  use Aurora.Uix.Gettext
+  use Aurora.Uix.GettextResolver
 
   @doc """
   Renders a file upload field.

--- a/lib/aurora_uix/templates/basic/renderers/form_renderer.ex
+++ b/lib/aurora_uix/templates/basic/renderers/form_renderer.ex
@@ -14,7 +14,7 @@ defmodule Aurora.Uix.Templates.Basic.Renderers.FormRenderer do
   """
 
   use Aurora.Uix.CoreComponentsImporter
-  use Aurora.Uix.Gettext
+  use Aurora.Uix.GettextResolver
 
   import Aurora.Uix.Templates.Basic.Components,
     only: [record_navigator_bar: 1, record_navigator?: 2]

--- a/lib/aurora_uix/templates/basic/renderers/form_renderer.ex
+++ b/lib/aurora_uix/templates/basic/renderers/form_renderer.ex
@@ -39,7 +39,7 @@ defmodule Aurora.Uix.Templates.Basic.Renderers.FormRenderer do
       <.record_navigator_bar :if={@action in [:edit, :show_edit] and record_navigator?(@auix, :top)} pagination={@auix.pagination} item_index={@auix.item_index} />
       <.header>
         {if @action in [:edit, :show_edit], do: dt(@auix.layout_options.edit_title), else: dt(@auix.layout_options.new_title)}
-        <:subtitle>{if @action in [:edit, :show_edit], do: @auix.layout_options.edit_subtitle, else: dt(@auix.layout_options.new_subtitle)}</:subtitle>
+        <:subtitle>{if @action in [:edit, :show_edit], do: dt(@auix.layout_options.edit_subtitle), else: dt(@auix.layout_options.new_subtitle)}</:subtitle>
         <:actions>
           <div name="auix-form-header-actions">
             <%= for %{function_component: action} <- @auix.form_header_actions do %>

--- a/lib/aurora_uix/templates/basic/renderers/index_renderer.ex
+++ b/lib/aurora_uix/templates/basic/renderers/index_renderer.ex
@@ -14,7 +14,7 @@ defmodule Aurora.Uix.Templates.Basic.Renderers.IndexRenderer do
   """
 
   use Aurora.Uix.CoreComponentsImporter
-  use Aurora.Uix.Gettext
+  use Aurora.Uix.GettextResolver
   use Phoenix.LiveView
 
   import Aurora.Uix.Templates.Basic.Components

--- a/lib/aurora_uix/templates/basic/renderers/index_renderer.ex
+++ b/lib/aurora_uix/templates/basic/renderers/index_renderer.ex
@@ -57,7 +57,7 @@ defmodule Aurora.Uix.Templates.Basic.Renderers.IndexRenderer do
         <div id={"auix-table-#{@auix.uri_path_id}-index-title"}>
           {dt(@auix.layout_options.page_title)}
         </div>
-        <:subtitle>
+        <:subtitle :if={! is_nil(@auix.layout_options.page_subtitle)}>
           {dt(@auix.layout_options.page_subtitle)}
         </:subtitle>
       </.header>

--- a/lib/aurora_uix/templates/basic/renderers/sections_renderer.ex
+++ b/lib/aurora_uix/templates/basic/renderers/sections_renderer.ex
@@ -11,7 +11,7 @@ defmodule Aurora.Uix.Templates.Basic.Renderers.SectionsRenderer do
   """
 
   use Aurora.Uix.CoreComponentsImporter
-  use Aurora.Uix.Gettext
+  use Aurora.Uix.GettextResolver
   alias Aurora.Uix.Templates.Basic.Renderer
 
   @doc """

--- a/lib/aurora_uix/templates/basic/renderers/show_component_renderer.ex
+++ b/lib/aurora_uix/templates/basic/renderers/show_component_renderer.ex
@@ -13,7 +13,7 @@ defmodule Aurora.Uix.Templates.Basic.Renderers.ShowComponentRenderer do
   """
 
   use Aurora.Uix.CoreComponentsImporter
-  use Aurora.Uix.Gettext
+  use Aurora.Uix.GettextResolver
   use Phoenix.LiveView
 
   import Aurora.Uix.Templates.Basic.Components,

--- a/lib/aurora_uix/templates/basic/themes/base.ex
+++ b/lib/aurora_uix/templates/basic/themes/base.ex
@@ -1374,7 +1374,7 @@ defmodule Aurora.Uix.Templates.Basic.Themes.Base do
     .auix-items-table-empty {
       width: 100%;
       text-align: center;
-      font-size: var(--auix-font-size-title);
+      font-size: var(--auix-font-size-empty-state);
       font-weight: var(--auix-font-weight-bold);
     }
     """
@@ -2158,8 +2158,8 @@ defmodule Aurora.Uix.Templates.Basic.Themes.Base do
     """
     .auix-group-title {
       margin: 0;
-      font-weight: var(--auix-font-weight-bold);     
-      font-size: var(--auix-font-size-title);
+      font-weight: var(--auix-font-weight-bold);
+      font-size: var(--auix-font-size-group-title);
     }
     """
   end

--- a/lib/aurora_uix/templates/basic/themes/base_variables.ex
+++ b/lib/aurora_uix/templates/basic/themes/base_variables.ex
@@ -71,6 +71,11 @@ defmodule Aurora.Uix.Templates.Basic.Themes.BaseVariables do
       --auix-font-size-subtitle: 1rem;
       --auix-font-size-caption: 0.875rem;
       --auix-font-size-small: 0.750rem;
+
+      /* Alias the title size so a host can resize the page title alone */
+      --auix-font-size-group-title: var(--auix-font-size-title);
+      --auix-font-size-empty-state: var(--auix-font-size-title);
+
       --auix-font-weight-bold: 600;
       --auix-font-weight-bold-semi: 400;
       --auix-font-style-mobile-viewmode: italic;

--- a/lib/aurora_uix/templates/basic/themes/theme_base.ex
+++ b/lib/aurora_uix/templates/basic/themes/theme_base.ex
@@ -82,8 +82,10 @@ defmodule Aurora.Uix.Templates.Basic.Themes.ThemeBase do
       /* containers */
       --auix-color-show-content-bg: var(--auix-color-bg-default);
       --auix-color-form-container-bg: var(--auix-color-bg-default);
-      --auix-color-group-container-border: var(--auix-color-border-primary);
-      --auix-color-group-container-bg: var(--auix-color-bg-light);
+      /* Flat by default — a group always sits inside a container that already
+         paints a card, so painting one here nests two identical surfaces */
+      --auix-color-group-container-border: transparent;
+      --auix-color-group-container-bg: transparent;
       --auix-color-one-to-many-text: var(--auix-color-text-primary);
       --auix-color-one-to-many-border: var(--auix-color-border-primary);
       --auix-color-form-field-input-border: var(--auix-color-border-primary);

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Aurora.Uix.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/wadvanced/aurora_uix"
-  @version "0.1.6-rc.2"
+  @version "0.1.6-rc.3"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -191,7 +191,7 @@ defmodule Aurora.Uix.MixProject do
             Aurora.Uix.ComponentsResolver,
             Aurora.Uix.ComponentsResolverHelper,
             Aurora.Uix.CoreComponentsImporter,
-            Aurora.Uix.Gettext,
+            Aurora.Uix.GettextResolver,
             Aurora.Uix.GettextBackend,
             Aurora.Uix.Helpers.Common,
             Aurora.Uix.RouteHelper

--- a/test/aurora_uix/helpers/gettext_resolver_test.exs
+++ b/test/aurora_uix/helpers/gettext_resolver_test.exs
@@ -1,6 +1,6 @@
-defmodule Aurora.Uix.Helpers.GettextTest do
+defmodule Aurora.Uix.Helpers.GettextResolverTest do
   use ExUnit.Case, async: true
-  use Aurora.Uix.Gettext
+  use Aurora.Uix.GettextResolver
 
   @spec test_translation() :: binary()
   def test_translation, do: dt("Save")
@@ -11,13 +11,13 @@ defmodule Aurora.Uix.Helpers.GettextTest do
   @spec passthrough(term()) :: term()
   def passthrough(value), do: dt(value)
 
-  describe "Aurora.Uix.Gettext" do
-    test "dt/1 is available after use Aurora.Uix.Gettext" do
+  describe "Aurora.Uix.GettextResolver" do
+    test "dt/1 is available after use Aurora.Uix.GettextResolver" do
       assert test_translation() == "Save"
     end
 
     test "@gettext_domain module attribute is set" do
-      assert gettext_domain() == nil
+      assert gettext_domain() == "default"
     end
 
     test "dt/1 leaves non-binary dynamic values unchanged" do

--- a/test/aurora_uix/templates/basic/gettext_coverage_test.exs
+++ b/test/aurora_uix/templates/basic/gettext_coverage_test.exs
@@ -53,19 +53,19 @@ defmodule Aurora.Uix.Templates.Basic.GettextCoverageTest do
       refute core_components =~ "gettext(\"close\")"
       refute core_components =~ "gettext(\"Success!\")"
       assert core_components =~ "dt(\"close\")"
-      assert core_components =~ "Gettext.dngettext(backend(), \"errors\""
-      assert core_components =~ "Gettext.dgettext(backend(), \"errors\""
+      assert core_components =~ "Gettext.dngettext(gettext_backend(), \"errors\""
+      assert core_components =~ "Gettext.dgettext(gettext_backend(), \"errors\""
     end
   end
 
   describe "form generator gettext extraction" do
-    test "generated modules always use Aurora.Uix.Gettext" do
+    test "generated modules always use Aurora.Uix.GettextResolver" do
       generated =
         sample_parsed_opts()
         |> FormGenerator.generate_module()
         |> Macro.to_string()
 
-      assert generated =~ "use Aurora.Uix.Gettext"
+      assert generated =~ "use Aurora.Uix.GettextResolver"
       refute generated =~ "_aurora_uix_extract"
     end
 
@@ -94,7 +94,7 @@ defmodule Aurora.Uix.Templates.Basic.GettextCoverageTest do
           |> compiled_module.generate_module()
           |> Macro.to_string()
 
-        assert generated =~ "use Aurora.Uix.Gettext"
+        assert generated =~ "use Aurora.Uix.GettextResolver"
         assert generated =~ "defp _aurora_uix_extract do"
         assert generated =~ "dgettext(\"forms\", \"Reference\")"
         assert length(Regex.scan(~r/dgettext\("forms", "Name"\)/, generated)) == 1

--- a/test/cases_live/ash_default_layout_test.exs
+++ b/test/cases_live/ash_default_layout_test.exs
@@ -164,7 +164,7 @@ defmodule Aurora.UixWeb.Test.AshDefaultLayoutTest do
 
     assert view
            |> element("div#auix-author-new-modal header")
-           |> render() =~ "Creates a new <strong>Author</strong> record in your database"
+           |> render() =~ "Creates a new &#39;Author&#39; record in your database"
 
     # Create unique test data
     unique_name = "Author-#{System.system_time(:nanosecond)}"
@@ -207,7 +207,7 @@ defmodule Aurora.UixWeb.Test.AshDefaultLayoutTest do
     assert view
            |> element("div#auix-author-edit-modal header")
            |> render() =~
-             "Use this form to manage <strong>Authors</strong> records in your database"
+             "Use this form to manage &#39;Authors&#39; records in your database"
 
     # Verify form fields are populated with existing values
     html = render(view)

--- a/test/cases_live/create_ui_default_layout_test.exs
+++ b/test/cases_live/create_ui_default_layout_test.exs
@@ -46,7 +46,7 @@ defmodule Aurora.UixWeb.Test.CreateUIDefaultLayoutTest do
 
     assert view
            |> element("div#auix-product-new-modal header")
-           |> render() =~ "Creates a new <strong>Product</strong> record in your database"
+           |> render() =~ "Creates a new &#39;Product&#39; record in your database"
 
     assert view
            |> form("#auix-product-form",
@@ -97,7 +97,7 @@ defmodule Aurora.UixWeb.Test.CreateUIDefaultLayoutTest do
     assert view
            |> element("div#auix-product-edit-modal header")
            |> render() =~
-             "Use this form to manage <strong>Products</strong> records in your database"
+             "Use this form to manage &#39;Products&#39; records in your database"
   end
 
   # A single-value select renders as `<select>` and a multi-value one as a group of checkboxes;

--- a/test/cases_live/embeds_one_test.exs
+++ b/test/cases_live/embeds_one_test.exs
@@ -43,7 +43,7 @@ defmodule Aurora.UixWeb.Test.EmbedsOneTest do
 
     {:ok, view, html} = live(conn, "/embeds-one-users/new")
     assert html =~ "Embeds one"
-    assert html =~ "Creates a new <strong>User</strong> record in your database"
+    assert html =~ "Creates a new &#39;User&#39; record in your database"
 
     view
     |> form(


### PR DESCRIPTION
> 🤖 **GENERATED-DESCRIPTION:START** — auto-generated; edit above or below, never inside.

## Summary
- Splits `--auix-font-size-title` into role-specific variables (`--auix-font-size-group-title`, `--auix-font-size-empty-state`), so a host can resize the page title alone without also growing group headings and index empty states; both default to the previous shared value.
- Makes `.auix-group-container` flat by default (`--auix-color-group-container-bg`/`-border` now `transparent`) since a group always renders inside a container that already paints a card (`.auix-show-content`, `.auix-form-container`, or `.auix-sections-content`), which previously produced visible card-in-card nesting on any `group`-based layout. Padding/border-width are unchanged.
- Fixes `edit_title`/`edit_subtitle`/`new_title`/`new_subtitle`/index and show `page_title`/`page_subtitle` options being routed through `LayoutOptions.render_binary/2`, a dead `~H`-sigil wrapper originally meant to embed raw HTML; the now-unused helper is removed and the index subtitle slot is hidden via `:if` instead of an always-present empty string.
- Drops the `<strong>…</strong>` markup the `:edit_subtitle`/`:new_subtitle` form defaults relied on that wrapping for, in favor of plain `'…'` quoting, and fixes `edit_subtitle` never being routed through `dt/1`/Gettext unlike its `new_subtitle`/`edit_title`/`new_title` siblings.
- Renames `Aurora.Uix.Gettext` to `Aurora.Uix.GettextResolver` across all call sites, since the old name shadowed the `Gettext` library module and blocked direct `Gettext.*` calls from code generated inside the macro's own `__using__/1` block; the macro's injected `backend/0` helper is also made private (`gettext_backend/0`).
- Updates the styling guide, layouts guide, and CHANGELOG to document the new theming variables, the flat-group default, and the fixes above.

> 🤖 **GENERATED-DESCRIPTION:END**
